### PR TITLE
chore(deps): add core-js and sharp to onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,9 +96,11 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "core-js",
       "electron",
       "electron-winstaller",
-      "esbuild"
+      "esbuild",
+      "sharp"
     ]
   },
   "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017"


### PR DESCRIPTION
## Summary
- Adds `core-js` and `sharp` to pnpm `onlyBuiltDependencies` list

## Test plan
- [ ] `pnpm install` completes without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)