### PR TITLE
fix(ui): disable entity/bin interaction when drawing tool active

### DIFF
--- a/src/renderer/src/components/layout/LayoutCanvas.tsx
+++ b/src/renderer/src/components/layout/LayoutCanvas.tsx
@@ -180,21 +180,22 @@ function LayoutScene({
         />
       ))}
 
-      {/* Bin drag handlers (only for selected bins) */}
-      {bins.map((bin) => (
-        <BinDragHandler
-          key={`drag-${bin.id}`}
-          bin={bin}
-          baseUnit={baseUnit}
-          onSelectBin={onSelectBin}
-          onBinMove={onBinMove}
-        />
-      ))}
+      {/* Bin drag handlers (only in select mode) */}
+      {activeTool === 'select' &&
+        bins.map((bin) => (
+          <BinDragHandler
+            key={`drag-${bin.id}`}
+            bin={bin}
+            baseUnit={baseUnit}
+            onSelectBin={onSelectBin}
+            onBinMove={onBinMove}
+          />
+        ))}
 
       <EntityRenderer
         entities={entities}
         selectedIds={selectionType === 'entity' ? selectedIds : new Set()}
-        onEntityClick={handleEntityClick}
+        onEntityClick={activeTool === 'select' ? handleEntityClick : undefined}
       />
 
       {/* Active tool */}


### PR DESCRIPTION
## Summary
- Entity click-to-select only fires when Select tool is active (not during circle/rect/polygon drawing)
- Bin drag handlers only render in Select mode — drawing tools pass clicks through to the tool handler
- Closes T219 from `specs/005-polish/tasks.md`

## Test plan
- [ ] Select the Circle tool, click inside a bin — should place a circle, not select/drag the bin
- [ ] Switch to Select tool — entity selection and bin dragging work normally
- [ ] Repeat for Rectangle and Polygon tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)