### PR TITLE
build: split vendor chunks and fix manifold module warning

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -45,7 +45,23 @@ export default defineConfig({
     resolve: {
       alias: {
         '@renderer': resolve('src/renderer/src'),
-        '@': resolve(__dirname, 'src/renderer/src')
+        '@': resolve(__dirname, 'src/renderer/src'),
+        // manifold-3d conditionally imports Node's "module" builtin (guarded by
+        // ENVIRONMENT_IS_NODE) — stub it out so Vite doesn't externalize + warn
+        module: resolve(__dirname, 'src/renderer/src/lib/empty-module.ts')
+      }
+    },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id): string | undefined {
+            if (id.includes('node_modules/three/')) return 'three'
+            if (id.includes('node_modules/react-dom/')) return 'react-dom'
+            if (id.includes('node_modules/@react-three/')) return 'r3f'
+            if (id.includes('node_modules/@radix-ui/')) return 'radix'
+            return undefined
+          }
+        }
       }
     },
     worker: {

--- a/src/renderer/src/lib/empty-module.ts
+++ b/src/renderer/src/lib/empty-module.ts
@@ -1,0 +1,5 @@
+// Stub for Node's "module" builtin — manifold-3d imports it conditionally
+// (guarded by ENVIRONMENT_IS_NODE) so this is never actually called in the renderer.
+export function createRequire(): never {
+  throw new Error('createRequire is not available in the renderer process')
+}


### PR DESCRIPTION
## Summary
- Split the monolithic 3.2MB renderer bundle into separate vendor chunks (`three`, `react-dom`, `r3f`, `radix`) — app code chunk drops to 474 KB
- Stub out Node's `module` builtin that manifold-3d conditionally imports, eliminating the "externalized for browser compatibility" warning without filtering

## Test plan
- [x] `pnpm build` passes with no warnings
- [x] Verify chunk output shows separate vendor files
- [ ] `pnpm dev` still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)