### PR TITLE
docs: add adapter-based modularity as constitutional principle VII

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,13 +1,10 @@
 <!--
 Sync Impact Report
 ===================
-Version change: N/A → 1.0.0 (initial ratification)
-Modified principles: N/A (initial)
+Version change: 1.0.0 → 1.1.0
+Modified principles: VII renumbered to VIII (Simplicity & YAGNI)
 Added sections:
-  - 7 Core Principles (I–VII)
-  - Development Constraints
-  - Quality Gates & Workflow
-  - Governance
+  - Principle VII: Adapter-Based Modularity
 Removed sections: N/A
 Templates requiring updates:
   - .specify/templates/plan-template.md — ✅ compatible (Constitution Check section present)
@@ -135,7 +132,42 @@ Skipping CI checks or force-pushing over failures is prohibited.
 **Rationale**: Consistent commit history enables automated changelogs
 via release-please and makes bisecting regressions tractable.
 
-### VII. Simplicity & YAGNI
+### VII. Adapter-Based Modularity
+
+Major subsystems MUST be decoupled from their implementation libraries
+through adapter interfaces. Application code consumes abstract
+interfaces; concrete library bindings live behind adapters that can be
+swapped, tested, or replaced independently.
+
+This principle applies to any component whose implementation is likely
+to evolve or where multiple viable libraries exist:
+
+- **Layout engine**: `LayoutEngine` interface with Fabric.js and Konva
+  adapters (established in 009/010).
+- **CSG/geometry pipeline**: adapter boundary between layout shapes and
+  the Manifold-based builder.
+- **Future candidates**: 3D preview renderer, file format exporters,
+  input handling layer.
+
+Concretely:
+
+- Define a TypeScript interface that captures the capability, not the
+  library's API surface.
+- Application components depend on the interface, never on library
+  imports directly.
+- Adapters convert between the interface's data model and the library's
+  internal representation at the boundary (e.g., lower-left corner ↔
+  centroid coordinate conversion).
+- Engine-agnostic snapshot/serialization — persisted data MUST NOT
+  contain library-specific artifacts.
+
+**Rationale**: Gridfinity Studio has already gone through three
+rendering technology changes (R3F → Fabric.js / Konva). The adapter
+pattern absorbs these migrations into localized adapter rewrites instead
+of app-wide refactors. It also enables runtime engine switching and
+side-by-side evaluation of alternatives.
+
+### VIII. Simplicity & YAGNI
 
 Every abstraction, dependency, and architectural decision MUST justify
 its existence against a simpler alternative:
@@ -205,4 +237,4 @@ comments, and verbal agreements.
 applicable principles. The plan template's "Constitution Check" section
 MUST be completed before implementation begins.
 
-**Version**: 1.0.0 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-03-04
+**Version**: 1.1.0 | **Ratified**: 2026-03-04 | **Last Amended**: 2026-03-08

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,17 @@ Conventional commits are **strictly enforced** by commitlint in CI and Husky pre
 
 ## Development Principles
 
+### Adapter-Based Modularity
+
+Major subsystems must be decoupled from their implementation libraries through adapter interfaces. Application code consumes abstract interfaces; concrete library bindings live behind adapters that can be swapped, tested, or replaced independently.
+
+- Define a TypeScript interface that captures the **capability**, not the library's API surface.
+- Application components depend on the interface, never on library imports directly.
+- Adapters convert between the interface's data model and the library's internals at the boundary (e.g., lower-left corner ↔ centroid coordinate conversion in the layout engine).
+- Persisted data must be engine-agnostic — no library-specific artifacts in snapshots or project files.
+
+**Established pattern**: The `LayoutEngine` interface with Fabric.js and Konva adapters (009/010). Future candidates include the CSG/geometry pipeline, 3D preview renderer, file format exporters, and input handling layer.
+
 ### Integration-First Development
 
 **Every feature must be exercised end-to-end before it is considered done.** Building a component in isolation and marking it complete is not acceptable — it must be mounted in the component tree, connected to state, and verified to actually work when a user interacts with it.

--- a/specs/010-layout-engine-integration/spec.md
+++ b/specs/010-layout-engine-integration/spec.md
@@ -208,6 +208,12 @@ This is a thin adapter. The CSG builder itself (`bin-csg-builder.ts`) and worker
 7. **Remove R3F entirely** — if 3D preview moves to raw Three.js, the R3F dependency can be dropped.
 8. **Pattern system** — generators/patterns become engine-level operations on shapes.
 
+### Design Principle: Adapter-Based Modularity
+
+The layout engine integration (009 + 010) established adapter-based modularity as a core project principle (Constitution VII). The `LayoutEngine` interface with Fabric.js and Konva adapters proved that major subsystems can be decoupled from their implementation libraries through abstract interfaces, enabling runtime swapping, independent testing, and localized migration when libraries change.
+
+This pattern should be extended to future subsystems: CSG/geometry pipeline, 3D preview renderer, file format exporters, and input handling. See the constitution for the full principle statement.
+
 ## Acceptance Criteria
 
 - [ ] Layout mode renders all shape types via LayoutEngine (no R3F)


### PR DESCRIPTION
## Summary
- Elevates the adapter pattern (established by layout engine 009/010) to a core constitutional principle
- Constitution bumped to v1.1.0 with new Principle VII: Adapter-Based Modularity
- CLAUDE.md updated with the principle in Development Principles
- 010 spec references it in Post-Integration Follow-up

## Why
We've now gone through three rendering tech changes (R3F → Fabric.js / Konva). The adapter pattern absorbed these into localized rewrites. This should be the default approach for all major subsystems going forward.

## Test plan
- [ ] Docs-only change — no code impact
- [ ] Constitution versioning is correct (1.0.0 → 1.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)