### PR TITLE
fix(core): normalize polygon position across Fabric/Konva engines

### DIFF
--- a/specs/010-layout-engine-integration/tasks.md
+++ b/specs/010-layout-engine-integration/tasks.md
@@ -36,11 +36,11 @@
 
 ## Phase 3: Drawing Tools
 
-- [ ] T021: Create `DrawingToolLayer` component — transparent DOM overlay active when tool is selected. Captures pointer events, converts to world coordinates via `engine.getViewport()`.
-- [ ] T022: Implement rectangle tool — click-drag to define corners, preview as temporary engine shape, release to place. Calls `engine.addShape({ type: 'rect', ... })`. Assigns to containing group if placed inside a bin.
-- [ ] T023: Implement circle tool — click for center, drag for radius preview, release to place. Creates `{ type: 'circle', radiusX, radiusY }`.
-- [ ] T024: Implement polygon tool — multi-click vertex placement, close-snap detection, double-click/Enter to finish. Creates `{ type: 'polygon', points }`.
-- [ ] T025: Wire pocket metadata — shapes created inside a bin group get `metadata: { pocket: { depth, clearance } }` with defaults computed from bin height.
+- [x] T021: Create `DrawingToolLayer` component — transparent DOM overlay active when tool is selected. Captures pointer events, converts to world coordinates via `engine.getViewport()`.
+- [x] T022: Implement rectangle tool — click-drag to define corners, preview as temporary engine shape, release to place. Calls `engine.addShape({ type: 'rect', ... })`. Assigns to containing group if placed inside a bin.
+- [x] T023: Implement circle tool — click for center, drag for radius preview, release to place. Creates `{ type: 'circle', radiusX, radiusY }`.
+- [x] T024: Implement polygon tool — multi-click vertex placement, close-snap detection, double-click/Enter to finish. Creates `{ type: 'polygon', points }`.
+- [x] T025: Wire pocket metadata — shapes created inside a bin group get `metadata: { pocket: { depth, clearance } }` with defaults computed from bin height.
 - [ ] T026: Smoke test — draw all shape types, verify they appear in engine, are selectable, belong to correct group, survive save/load.
 
 ## Phase 4: CSG Pipeline Adapter
@@ -80,7 +80,7 @@
 |-------|-------|--------|
 | 1 | T001–T011 | Done (except T011 smoke test) |
 | 2 | T012–T020 | Partially done (T012-T014, T016-T017) |
-| 3 | T021–T026 | Not started |
+| 3 | T021–T026 | T021-T025 done, T026 smoke test remaining |
 | 4 | T027–T032 | Not started |
 | 5 | T033–T038 | Partially done (T033-T035, T037) |
 | 6 | T039–T048 | Done (except T047 CLAUDE.md, T048 final) |

--- a/specs/011-coordinate-snap-system/spec.md
+++ b/specs/011-coordinate-snap-system/spec.md
@@ -1,0 +1,134 @@
+# 011: Coordinate System Standardization & Smart Snap
+
+**Status**: Draft
+**Issue**: #253
+**Depends on**: 010-layout-engine-integration (Phase 3 drawing tools)
+
+## Problem
+
+The layout engine currently has a single grid system (42mm Gridfinity module grid) that controls both bin placement and shape snapping. This is wrong for shapes — pocket cutouts and decorative geometry need millimeter-precision placement, not 42mm jumps. The drawing tools work around this by bypassing the engine grid entirely, but this means shapes have no snap at all unless Shift is held.
+
+We need two distinct coordinate systems with independent snap behavior, clear visual representation, and consistent rules across all interaction modes (draw, move, resize, rotate, nudge).
+
+## Design
+
+### Two Coordinate Systems
+
+#### Grid (Gridfinity module grid)
+- **Purpose**: Bin placement and sizing
+- **Unit**: Always millimeters, derived from `project.gridfinity.baseUnit` (default 42mm)
+- **Snap reference**: Lower-left corner of bin groups
+- **Visual**: Solid lines (current behavior), major lines at `baseUnit`, subdivision lines at `baseUnit / 4`
+- **Code name**: `grid` / `GridConfig`
+
+#### Snap (Design detail grid)
+- **Purpose**: Shape placement, drawing, resizing, rotating
+- **Unit**: Follows user's preferred display unit (mm or inch)
+- **Step sizes**: Two tiers — fine (default) and coarse (Shift held)
+- **Snap reference**: Centroid for move/draw, edge/corner for resize, angle for rotate
+- **Visual**: Distinct from module grid — dotted or dashed lines, muted color, hidden when zoomed out past a threshold
+- **Code name**: `snap` / `SnapConfig`
+
+### Snap Configuration
+
+Stored in **app preferences** (not per-project), with values for both unit systems so switching project units is seamless:
+
+```typescript
+interface SnapPreferences {
+  mm: { fine: number; coarse: number }   // default: 1mm / 5mm
+  inch: { fine: number; coarse: number } // default: 0.1in / 0.5in
+  rotateAngle: number                    // default: 15 degrees
+}
+```
+
+The active snap step is resolved at runtime from the project's unit system + the preference tier.
+
+### Modifier Key Model
+
+| Modifier | Move/Draw | Resize | Rotate |
+|----------|-----------|--------|--------|
+| None | Fine snap | Free | Free |
+| Shift | Coarse snap | Snap to step | Snap to angle |
+| Alt/Option | Free (no snap) | Free | Free |
+
+### Absolute Snap (No Relative Offset)
+
+Snap positions are always absolute to the grid origin. If a shape sits at 10.3mm and the user drags it with 1mm snap active, it jumps to 10mm or 11mm — not 10.3 + N. Any off-grid offset from a previous free-move is forgotten.
+
+### Selection Snap Rules
+
+The snap system used depends on what's selected:
+
+| Selection | Snap system | Reference point |
+|-----------|-------------|-----------------|
+| Single shape | Snap (detail) | Shape centroid |
+| Multiple shapes | Snap (detail) | Selection centroid |
+| Single bin | Grid (module) | Lower-left corner |
+| Multiple bins | Grid (module) | First bin lower-left |
+| Mixed (bins + shapes) | Grid (module) | Bin lower-left corner |
+
+The mixed-selection rule ensures shapes inside a bin don't shift relative to the bin when the whole assembly is moved.
+
+### Arrow Key Nudge
+
+- Default: move by fine snap step
+- Shift + arrow: move by coarse snap step
+- Alt + arrow: move by 1 pixel (screen space)
+
+Nudge respects the same selection snap rules above.
+
+## Visual Grid Rendering
+
+Both grids render simultaneously on canvas:
+
+- **Module grid** (bins): Solid lines, current styling. Major at `baseUnit`, minor at `baseUnit / 4`.
+- **Detail grid** (shapes): Dotted or short-dash lines in a contrasting muted color. Rendered at the active fine snap interval.
+- **Zoom-adaptive visibility**: Detail grid lines fade out below a minimum screen-pixel spacing (e.g., hide when lines would be < 4px apart). Module grid already has this behavior.
+- **Grid origin**: Both grids share the same origin (0, 0).
+
+## Existing Code Impact
+
+### Drawing tools (`DrawingToolLayer.tsx`)
+Currently has its own `snapShape()` with hardcoded 1mm fine snap. Replace with snap system that reads from app preferences and respects modifier keys.
+
+### Engine snap handlers
+- `fabric-engine.ts` `setupSnapToGrid()`: Currently snaps everything to module grid. Needs to distinguish bins (grid snap) from shapes (detail snap or free).
+- `konva-engine.ts` `dragmove`/`dragend`: Same — bins snap to grid, shapes to detail snap.
+- Both engines need modifier key awareness (Shift/Alt) during drag.
+
+### App preferences
+- `PreferencesModal.tsx`: Add snap configuration UI (fine/coarse steps for mm and inch, rotate angle).
+- Need a new preferences store or extend the existing one.
+
+### Engine interface
+- `LayoutEngine` interface may need `setSnapConfig()` alongside `setGridConfig()`.
+- Or snap can live entirely in the React layer (drawing overlay + move handlers) without the engine knowing about it. TBD based on implementation complexity.
+
+## Future Extensions
+
+### Center snap
+Snap shape to the center of its containing bin. Useful for centered pocket cutouts.
+
+### Edge/object snap
+Snap to edges or centers of other shapes. Common in CAD tools. Lower priority.
+
+### Resize snap
+When resizing a shape, the dragged edge/corner snaps to the detail grid. The anchor point (opposite edge/corner) stays fixed. Activated by holding Shift during resize.
+
+### Rotate snap
+Holding Shift while rotating snaps to `rotateAngle` increments (default 15°). The rotation origin is the shape's center.
+
+### User-space grouping (Cmd+G)
+Distinct from bin groups (LayoutGroup). User groups:
+- Move as a unit, snap by group centroid
+- No bin metadata
+- Can exist inside bins or free on canvas
+- Nesting TBD (groups of groups vs flat)
+
+This requires a new entity type or a flag on LayoutGroup to distinguish user groups from bin groups.
+
+## Non-Goals (This Spec)
+
+- Implementing all snap modes — this spec covers the architecture and the core move/draw snap. Resize snap, rotate snap, center snap, and object snap are future work.
+- User-space grouping implementation — architecture only.
+- Keyboard shortcut customization — snap uses hardcoded Shift/Alt for now.

--- a/specs/011-coordinate-snap-system/tasks.md
+++ b/specs/011-coordinate-snap-system/tasks.md
@@ -1,0 +1,49 @@
+# 011: Coordinate Snap System — Tasks
+
+## Phase 1: Snap Infrastructure
+
+- [ ] T001: Define `SnapConfig` type and `SnapPreferences` in shared types. Include fine/coarse steps for mm and inch, rotate angle.
+- [ ] T002: Add snap preferences to app preferences store (persist to disk). Default: 1mm/5mm fine/coarse, 0.1in/0.5in, 15° rotate.
+- [ ] T003: Add snap configuration UI to PreferencesModal — fine/coarse step inputs for both unit systems, rotate angle input.
+- [ ] T004: Create `useSnapConfig()` hook that resolves the active snap step from project unit system + app preferences + current modifier key state.
+
+## Phase 2: Drawing Tool Snap
+
+- [ ] T005: Replace hardcoded 1mm snap in `DrawingToolLayer.tsx` with `useSnapConfig()`. Respect fine/coarse/free modifiers during draw.
+- [ ] T006: Verify all three drawing tools (rect, circle, polygon) use the new snap system correctly.
+
+## Phase 3: Engine Move Snap
+
+- [ ] T007: Refactor Fabric `setupSnapToGrid()` — bins snap to module grid (as today), shapes snap to detail snap step based on modifier key.
+- [ ] T008: Refactor Konva shape drag handlers — same logic as T007.
+- [ ] T009: Implement absolute snap (forget off-grid offset) for shapes in both engines.
+- [ ] T010: Implement selection-aware snap rules: shapes-only → detail snap, bins → module grid, mixed → module grid.
+
+## Phase 4: Visual Grid
+
+- [ ] T011: Render detail snap grid in Fabric engine — dotted/dashed lines at fine snap interval, distinct color from module grid.
+- [ ] T012: Render detail snap grid in Konva engine — same visual treatment.
+- [ ] T013: Zoom-adaptive visibility — fade out detail grid when lines would be < 4px apart on screen.
+
+## Phase 5: Arrow Key Nudge
+
+- [ ] T014: Implement arrow key nudge for selected shapes/bins. Fine step default, Shift for coarse, Alt for 1px.
+- [ ] T015: Nudge respects selection snap rules (shapes use detail snap, bins use module grid).
+
+## Phase 6: Future (not in initial scope)
+
+- [ ] T016: Resize snap — Shift during resize snaps dragged edge/corner to detail grid.
+- [ ] T017: Rotate snap — Shift during rotate snaps to configured angle increments.
+- [ ] T018: Center snap — snap shape to center of containing bin.
+- [ ] T019: User-space grouping (Cmd+G) — new group type, move/snap as unit.
+
+## Progress
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| 1 | T001–T004 | Not started |
+| 2 | T005–T006 | Not started |
+| 3 | T007–T010 | Not started |
+| 4 | T011–T013 | Not started |
+| 5 | T014–T015 | Not started |
+| 6 | T016–T019 | Future |

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect } from 'react'
 import Navbar from '@/components/Navbar'
 import Sidebar from '@/components/Sidebar'
 import Viewport from '@/components/Viewport'
@@ -7,17 +7,9 @@ import { ThemeProvider } from '@unstable-studios/ui'
 import { AppModeCtx, useAppMode } from '@/hooks/useAppMode'
 import { useProject } from '@/hooks/useProject'
 import { ReviewPrefsCtx } from '@/hooks/useReviewPrefs'
-import { UndoRedoCtx } from '@/hooks/useUndoRedo'
-import { LayoutEngineProvider, useLayoutEngineContext, useEngineUndoRedo } from '@/layout-engine'
+import { LayoutEngineProvider } from '@/layout-engine'
 import type { AppMode, ActiveTool } from '@/hooks/useAppMode'
 import type { EngineType } from '@/layout-engine'
-
-function UndoRedoProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
-  const { engine } = useLayoutEngineContext()
-  const { undo, redo, canUndo, canRedo } = useEngineUndoRedo(engine)
-  const value = useMemo(() => ({ undo, redo, canUndo, canRedo }), [undo, redo, canUndo, canRedo])
-  return <UndoRedoCtx.Provider value={value}>{children}</UndoRedoCtx.Provider>
-}
 
 function AppContent(): React.JSX.Element {
   const { project } = useProject()
@@ -30,15 +22,13 @@ function AppContent(): React.JSX.Element {
   // Always mount the engine provider so state survives mode switches
   return (
     <LayoutEngineProvider engineType={engineType}>
-      <UndoRedoProvider>
-        {/* Navbar: solid bar at top */}
-        <Navbar />
-        {/* Canvas fills remaining space; sidebar floats above it */}
-        <div className="relative flex-1 min-h-0 overflow-hidden">
-          <Viewport />
-          <Sidebar />
-        </div>
-      </UndoRedoProvider>
+      {/* Navbar: solid bar at top */}
+      <Navbar />
+      {/* Canvas fills remaining space; sidebar floats above it */}
+      <div className="relative flex-1 min-h-0 overflow-hidden">
+        <Viewport />
+        <Sidebar />
+      </div>
     </LayoutEngineProvider>
   )
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import Navbar from '@/components/Navbar'
 import Sidebar from '@/components/Sidebar'
 import Viewport from '@/components/Viewport'
@@ -7,9 +7,17 @@ import { ThemeProvider } from '@unstable-studios/ui'
 import { AppModeCtx, useAppMode } from '@/hooks/useAppMode'
 import { useProject } from '@/hooks/useProject'
 import { ReviewPrefsCtx } from '@/hooks/useReviewPrefs'
-import { LayoutEngineProvider } from '@/layout-engine'
+import { UndoRedoCtx } from '@/hooks/useUndoRedo'
+import { LayoutEngineProvider, useLayoutEngineContext, useEngineUndoRedo } from '@/layout-engine'
 import type { AppMode, ActiveTool } from '@/hooks/useAppMode'
 import type { EngineType } from '@/layout-engine'
+
+function UndoRedoProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const { engine } = useLayoutEngineContext()
+  const { undo, redo, canUndo, canRedo } = useEngineUndoRedo(engine)
+  const value = useMemo(() => ({ undo, redo, canUndo, canRedo }), [undo, redo, canUndo, canRedo])
+  return <UndoRedoCtx.Provider value={value}>{children}</UndoRedoCtx.Provider>
+}
 
 function AppContent(): React.JSX.Element {
   const { project } = useProject()
@@ -19,20 +27,20 @@ function AppContent(): React.JSX.Element {
     return <WelcomeScreen />
   }
 
-  const content = (
-    <>
-      {/* Navbar: solid bar at top */}
-      <Navbar />
-      {/* Canvas fills remaining space; sidebar floats above it */}
-      <div className="relative flex-1 min-h-0 overflow-hidden">
-        <Viewport />
-        <Sidebar />
-      </div>
-    </>
-  )
-
   // Always mount the engine provider so state survives mode switches
-  return <LayoutEngineProvider engineType={engineType}>{content}</LayoutEngineProvider>
+  return (
+    <LayoutEngineProvider engineType={engineType}>
+      <UndoRedoProvider>
+        {/* Navbar: solid bar at top */}
+        <Navbar />
+        {/* Canvas fills remaining space; sidebar floats above it */}
+        <div className="relative flex-1 min-h-0 overflow-hidden">
+          <Viewport />
+          <Sidebar />
+        </div>
+      </UndoRedoProvider>
+    </LayoutEngineProvider>
+  )
 }
 
 const APP_MODE_KEY = 'gfstudio:appMode'

--- a/src/renderer/src/components/DrawingToolLayer.tsx
+++ b/src/renderer/src/components/DrawingToolLayer.tsx
@@ -10,8 +10,9 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppMode } from '@/hooks/useAppMode'
 import { useLayoutEngineContext, useEngineState } from '@/layout-engine'
 import type { LayoutEngine } from '@/layout-engine'
-import type { LayoutShape, BinMetadata } from '@/layout-engine/types'
+import type { LayoutShape, BinMetadata, LayoutGroup } from '@/layout-engine/types'
 import { isBinGroup } from '@/layout-engine/types'
+import { computeDefaultPocketDepth } from '../../../shared/types/project'
 
 // ─── Coordinate conversion ──────────────────────────────────────────────────
 
@@ -98,46 +99,38 @@ function nextShapeName(engine: LayoutEngine, type: string): string {
 
 // ─── Bin hit testing ────────────────────────────────────────────────────────
 
-function pocketMetadata(
+/** Find the bin group containing a world-space point, if any. */
+function findContainingBinGroup(
   engine: LayoutEngine,
   worldX: number,
   worldY: number
-): Record<string, unknown> | undefined {
+): (LayoutGroup & { metadata: BinMetadata }) | null {
   const groups = engine.getAllGroups()
   for (const group of groups) {
     if (!isBinGroup(group)) continue
+    // Lower-left corner convention: group extends rightward (+x) and upward (-y)
     if (
       worldX >= group.x &&
       worldX <= group.x + group.width &&
       worldY <= group.y &&
       worldY >= group.y - group.height
     ) {
-      const meta = group.metadata as BinMetadata
-      return {
-        pocket: {
-          depth: meta.heightUnits * 7,
-          clearance: 0.25
-        }
-      }
-    }
-  }
-  return undefined
-}
-
-function findContainingGroup(engine: LayoutEngine, worldX: number, worldY: number): string | null {
-  const groups = engine.getAllGroups()
-  for (const group of groups) {
-    if (!isBinGroup(group)) continue
-    if (
-      worldX >= group.x &&
-      worldX <= group.x + group.width &&
-      worldY <= group.y &&
-      worldY >= group.y - group.height
-    ) {
-      return group.id
+      return group
     }
   }
   return null
+}
+
+function pocketMetadata(
+  bin: (LayoutGroup & { metadata: BinMetadata }) | null
+): Record<string, unknown> | undefined {
+  if (!bin) return undefined
+  return {
+    pocket: {
+      depth: computeDefaultPocketDepth(bin.metadata.heightUnits, 7),
+      clearance: 0.25
+    }
+  }
 }
 
 // ─── Drawing state (shared across tools) ────────────────────────────────────
@@ -216,7 +209,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
       const cy = pts.reduce((sum, p) => sum + p.y, 0) / pts.length
       const relativePoints = pts.map((p) => ({ x: p.x - cx, y: p.y - cy }))
 
-      const groupId = findContainingGroup(engine, cx, cy)
+      const bin = findContainingBinGroup(engine, cx, cy)
       const id = crypto.randomUUID()
       const name = nextShapeName(engine, 'polygon')
 
@@ -227,8 +220,8 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
         y: cy,
         points: relativePoints,
         ...baseShapeProps(),
-        groupId,
-        metadata: { ...pocketMetadata(engine, cx, cy), name }
+        groupId: bin?.id ?? null,
+        metadata: { ...pocketMetadata(bin), name }
       })
       engine.select([id])
       setState(INITIAL_STATE)
@@ -359,8 +352,8 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             height: h
           } as Partial<LayoutShape>)
         } else {
-          const dx = world.x - start.x
-          const dy = world.y - start.y
+          const dx = snapped.x - start.x
+          const dy = snapped.y - start.y
           const radius = Math.sqrt(dx * dx + dy * dy)
           engine.updateShape(previewIdRef.current, {
             radiusX: radius,
@@ -411,7 +404,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
           const y = Math.min(start.y, snapped.y)
           const cx = x + w / 2
           const cy = y + h / 2
-          const groupId = findContainingGroup(engine, cx, cy)
+          const bin = findContainingBinGroup(engine, cx, cy)
           const id = crypto.randomUUID()
           const name = nextShapeName(engine, 'rect')
           engine.addShape({
@@ -422,18 +415,18 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             width: w,
             height: h,
             ...baseShapeProps(),
-            groupId,
-            metadata: { ...pocketMetadata(engine, cx, cy), name }
+            groupId: bin?.id ?? null,
+            metadata: { ...pocketMetadata(bin), name }
           })
           engine.select([id])
           setActiveTool('select')
         }
       } else {
-        const dx = world.x - start.x
-        const dy = world.y - start.y
+        const dx = snapped.x - start.x
+        const dy = snapped.y - start.y
         const radius = Math.sqrt(dx * dx + dy * dy)
         if (radius > 2) {
-          const groupId = findContainingGroup(engine, start.x, start.y)
+          const bin = findContainingBinGroup(engine, start.x, start.y)
           const id = crypto.randomUUID()
           const name = nextShapeName(engine, 'circle')
           engine.addShape({
@@ -444,8 +437,8 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             radiusX: radius,
             radiusY: radius,
             ...baseShapeProps(),
-            groupId,
-            metadata: { ...pocketMetadata(engine, start.x, start.y), name }
+            groupId: bin?.id ?? null,
+            metadata: { ...pocketMetadata(bin), name }
           })
           engine.select([id])
           setActiveTool('select')

--- a/src/renderer/src/components/DrawingToolLayer.tsx
+++ b/src/renderer/src/components/DrawingToolLayer.tsx
@@ -29,21 +29,25 @@ function screenToWorld(
   }
 }
 
-// ─── Grid snap helper ───────────────────────────────────────────────────────
+// ─── Shape snap grid ────────────────────────────────────────────────────────
+// Shapes snap to a finer grid than bins. Default: no snap (free draw).
+// Hold Shift for fine snap (1mm). This is separate from the engine's bin grid.
 
-function snapToGrid(value: number, gridSize: number, enabled: boolean): number {
-  if (!enabled) return value
-  return Math.round(value / gridSize) * gridSize
+const FINE_SNAP = 1 // mm
+
+function snapShape(value: number, shiftHeld: boolean): number {
+  if (!shiftHeld) return value
+  const size = FINE_SNAP
+  return Math.round(value / size) * size
 }
 
-function snapPoint(
+function snapShapePoint(
   world: { x: number; y: number },
-  engine: LayoutEngine
+  shiftHeld: boolean
 ): { x: number; y: number } {
-  const grid = engine.getGridConfig()
   return {
-    x: snapToGrid(world.x, grid.size, grid.enabled),
-    y: snapToGrid(world.y, grid.size, grid.enabled)
+    x: snapShape(world.x, shiftHeld),
+    y: snapShape(world.y, shiftHeld)
   }
 }
 
@@ -68,6 +72,28 @@ function baseShapeProps(): Pick<
     strokeWidth: SHAPE_STROKE_WIDTH,
     groupId: null
   }
+}
+
+// ─── Shape naming ───────────────────────────────────────────────────────────
+
+const SHAPE_TYPE_LABELS: Record<string, string> = {
+  rect: 'Rectangle',
+  circle: 'Ellipse',
+  polygon: 'Polygon'
+}
+
+function nextShapeName(engine: LayoutEngine, type: string): string {
+  const label = SHAPE_TYPE_LABELS[type] ?? type
+  const shapes = engine.getAllShapes()
+  let max = 0
+  for (const s of shapes) {
+    const name = s.metadata?.name as string | undefined
+    if (name?.startsWith(label + ' ')) {
+      const num = parseInt(name.slice(label.length + 1), 10)
+      if (!isNaN(num) && num > max) max = num
+    }
+  }
+  return `${label} ${max + 1}`
 }
 
 // ─── Bin hit testing ────────────────────────────────────────────────────────
@@ -117,11 +143,8 @@ function findContainingGroup(engine: LayoutEngine, worldX: number, worldY: numbe
 // ─── Drawing state (shared across tools) ────────────────────────────────────
 
 interface DrawingState {
-  /** Polygon vertices (absolute world coords) */
   polygonVertices: { x: number; y: number }[]
-  /** Current cursor position for polygon preview */
   polygonCursor: { x: number; y: number } | null
-  /** Whether cursor is near first polygon vertex */
   polygonNearClose: boolean
 }
 
@@ -141,7 +164,6 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
   const { viewport } = useEngineState()
 
   // Reset polygon state when switching away from polygon tool.
-  // This is the React-recommended "adjusting state during render" pattern.
   const prevToolRef = useRef(activeTool)
   const [state, setState] = useState<DrawingState>(INITIAL_STATE)
   // eslint-disable-next-line react-hooks/refs -- prevToolRef tracks prop transitions during render (React docs pattern)
@@ -157,6 +179,8 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
   const dragStartRef = useRef<{ x: number; y: number } | null>(null)
   const previewIdRef = useRef<string | null>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
+  // Guard against double finishPolygon calls (StrictMode)
+  const finishingRef = useRef(false)
 
   // ─── Cleanup on tool switch ─────────────────────────────────────────────
 
@@ -169,20 +193,24 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
   }, [engine])
 
   useEffect(() => {
-    // When tool changes away from a drawing tool, clean up
     return () => {
       cleanupPreview()
     }
   }, [activeTool, cleanupPreview])
 
-  // ─── Escape / Enter for polygon ──────────────────────────────────────────
+  // ─── Finish polygon ───────────────────────────────────────────────────────
 
   const finishPolygon = useCallback(
     (pts: { x: number; y: number }[]) => {
       if (!engine || pts.length < 3) {
         setState(INITIAL_STATE)
+        finishingRef.current = false
         return
       }
+
+      // Guard against StrictMode double-fire
+      if (finishingRef.current) return
+      finishingRef.current = true
 
       const cx = pts.reduce((sum, p) => sum + p.x, 0) / pts.length
       const cy = pts.reduce((sum, p) => sum + p.y, 0) / pts.length
@@ -190,6 +218,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
 
       const groupId = findContainingGroup(engine, cx, cy)
       const id = crypto.randomUUID()
+      const name = nextShapeName(engine, 'polygon')
 
       engine.addShape({
         id,
@@ -199,14 +228,21 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
         points: relativePoints,
         ...baseShapeProps(),
         groupId,
-        metadata: pocketMetadata(engine, cx, cy)
+        metadata: { ...pocketMetadata(engine, cx, cy), name }
       })
       engine.select([id])
       setState(INITIAL_STATE)
       setActiveTool('select')
+
+      // Reset guard after microtask
+      queueMicrotask(() => {
+        finishingRef.current = false
+      })
     },
     [engine, setActiveTool]
   )
+
+  // ─── Escape / Enter for polygon ──────────────────────────────────────────
 
   useEffect(() => {
     if (activeTool !== 'polygon') return
@@ -216,7 +252,6 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
       } else if (e.key === 'Enter') {
         setState((prev) => {
           if (prev.polygonVertices.length >= 3) {
-            // Schedule finishPolygon outside setState
             queueMicrotask(() => finishPolygon(prev.polygonVertices))
           }
           return prev
@@ -234,7 +269,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
       const overlay = overlayRef.current
       if (!engine || !overlay || e.button !== 0) return
       const world = screenToWorld(e.clientX, e.clientY, overlay, engine)
-      const snapped = snapPoint(world, engine)
+      const snapped = snapShapePoint(world, e.shiftKey)
 
       if (activeTool === 'rectangle' || activeTool === 'circle') {
         dragStartRef.current = snapped
@@ -309,7 +344,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
         dragStartRef.current &&
         previewIdRef.current
       ) {
-        const snapped = snapPoint(world, engine)
+        const snapped = snapShapePoint(world, e.shiftKey)
         const start = dragStartRef.current
 
         if (activeTool === 'rectangle') {
@@ -333,7 +368,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
           } as Partial<LayoutShape>)
         }
       } else if (activeTool === 'polygon') {
-        const snapped = snapPoint(world, engine)
+        const snapped = snapShapePoint(world, e.shiftKey)
         setState((prev) => {
           if (prev.polygonVertices.length === 0) return prev
           let nearClose = false
@@ -361,7 +396,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
       if (!dragStartRef.current || !previewIdRef.current) return
 
       const world = screenToWorld(e.clientX, e.clientY, overlay, engine)
-      const snapped = snapPoint(world, engine)
+      const snapped = snapShapePoint(world, e.shiftKey)
       const start = dragStartRef.current
 
       // Remove preview
@@ -378,6 +413,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
           const cy = y + h / 2
           const groupId = findContainingGroup(engine, cx, cy)
           const id = crypto.randomUUID()
+          const name = nextShapeName(engine, 'rect')
           engine.addShape({
             id,
             type: 'rect',
@@ -387,7 +423,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             height: h,
             ...baseShapeProps(),
             groupId,
-            metadata: pocketMetadata(engine, cx, cy)
+            metadata: { ...pocketMetadata(engine, cx, cy), name }
           })
           engine.select([id])
           setActiveTool('select')
@@ -399,6 +435,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
         if (radius > 2) {
           const groupId = findContainingGroup(engine, start.x, start.y)
           const id = crypto.randomUUID()
+          const name = nextShapeName(engine, 'circle')
           engine.addShape({
             id,
             type: 'circle',
@@ -408,7 +445,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             radiusY: radius,
             ...baseShapeProps(),
             groupId,
-            metadata: pocketMetadata(engine, start.x, start.y)
+            metadata: { ...pocketMetadata(engine, start.x, start.y), name }
           })
           engine.select([id])
           setActiveTool('select')

--- a/src/renderer/src/components/DrawingToolLayer.tsx
+++ b/src/renderer/src/components/DrawingToolLayer.tsx
@@ -1,0 +1,497 @@
+/**
+ * Transparent DOM overlay that captures pointer events when a drawing tool
+ * is active (rectangle, circle, polygon). Converts screen coordinates to
+ * engine world coordinates and drives tool-specific state machines.
+ *
+ * Mounted on top of the engine canvas in layout mode only.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAppMode } from '@/hooks/useAppMode'
+import { useLayoutEngineContext, useEngineState } from '@/layout-engine'
+import type { LayoutEngine } from '@/layout-engine'
+import type { LayoutShape, BinMetadata } from '@/layout-engine/types'
+import { isBinGroup } from '@/layout-engine/types'
+
+// ─── Coordinate conversion ──────────────────────────────────────────────────
+
+function screenToWorld(
+  clientX: number,
+  clientY: number,
+  overlayEl: HTMLDivElement,
+  engine: LayoutEngine
+): { x: number; y: number } {
+  const rect = overlayEl.getBoundingClientRect()
+  const vp = engine.getViewport()
+  return {
+    x: (clientX - rect.left + vp.panX) / vp.zoom,
+    y: (clientY - rect.top + vp.panY) / vp.zoom
+  }
+}
+
+// ─── Grid snap helper ───────────────────────────────────────────────────────
+
+function snapToGrid(value: number, gridSize: number, enabled: boolean): number {
+  if (!enabled) return value
+  return Math.round(value / gridSize) * gridSize
+}
+
+function snapPoint(
+  world: { x: number; y: number },
+  engine: LayoutEngine
+): { x: number; y: number } {
+  const grid = engine.getGridConfig()
+  return {
+    x: snapToGrid(world.x, grid.size, grid.enabled),
+    y: snapToGrid(world.y, grid.size, grid.enabled)
+  }
+}
+
+// ─── Shape defaults ─────────────────────────────────────────────────────────
+
+const SHAPE_FILL = 'rgba(168, 85, 247, 0.12)'
+const SHAPE_STROKE = '#a855f7'
+const SHAPE_STROKE_WIDTH = 1
+
+const PREVIEW_FILL = 'rgba(168, 85, 247, 0.06)'
+const PREVIEW_STROKE = 'rgba(168, 85, 247, 0.5)'
+const PREVIEW_STROKE_WIDTH = 1
+
+function baseShapeProps(): Pick<
+  LayoutShape,
+  'rotation' | 'fill' | 'stroke' | 'strokeWidth' | 'groupId'
+> {
+  return {
+    rotation: 0,
+    fill: SHAPE_FILL,
+    stroke: SHAPE_STROKE,
+    strokeWidth: SHAPE_STROKE_WIDTH,
+    groupId: null
+  }
+}
+
+// ─── Bin hit testing ────────────────────────────────────────────────────────
+
+function pocketMetadata(
+  engine: LayoutEngine,
+  worldX: number,
+  worldY: number
+): Record<string, unknown> | undefined {
+  const groups = engine.getAllGroups()
+  for (const group of groups) {
+    if (!isBinGroup(group)) continue
+    if (
+      worldX >= group.x &&
+      worldX <= group.x + group.width &&
+      worldY <= group.y &&
+      worldY >= group.y - group.height
+    ) {
+      const meta = group.metadata as BinMetadata
+      return {
+        pocket: {
+          depth: meta.heightUnits * 7,
+          clearance: 0.25
+        }
+      }
+    }
+  }
+  return undefined
+}
+
+function findContainingGroup(engine: LayoutEngine, worldX: number, worldY: number): string | null {
+  const groups = engine.getAllGroups()
+  for (const group of groups) {
+    if (!isBinGroup(group)) continue
+    if (
+      worldX >= group.x &&
+      worldX <= group.x + group.width &&
+      worldY <= group.y &&
+      worldY >= group.y - group.height
+    ) {
+      return group.id
+    }
+  }
+  return null
+}
+
+// ─── Drawing state (shared across tools) ────────────────────────────────────
+
+interface DrawingState {
+  /** Polygon vertices (absolute world coords) */
+  polygonVertices: { x: number; y: number }[]
+  /** Current cursor position for polygon preview */
+  polygonCursor: { x: number; y: number } | null
+  /** Whether cursor is near first polygon vertex */
+  polygonNearClose: boolean
+}
+
+const INITIAL_STATE: DrawingState = {
+  polygonVertices: [],
+  polygonCursor: null,
+  polygonNearClose: false
+}
+
+const CLOSE_SNAP_DISTANCE = 10
+
+// ─── Main Component ─────────────────────────────────────────────────────────
+
+export default function DrawingToolLayer(): React.JSX.Element | null {
+  const { activeTool, setActiveTool } = useAppMode()
+  const { engine } = useLayoutEngineContext()
+  const { viewport } = useEngineState()
+
+  // Reset polygon state when switching away from polygon tool.
+  // This is the React-recommended "adjusting state during render" pattern.
+  const prevToolRef = useRef(activeTool)
+  const [state, setState] = useState<DrawingState>(INITIAL_STATE)
+  // eslint-disable-next-line react-hooks/refs -- prevToolRef tracks prop transitions during render (React docs pattern)
+  if (prevToolRef.current !== activeTool) {
+    // eslint-disable-next-line react-hooks/refs -- writing tracked prop value
+    prevToolRef.current = activeTool
+    if (activeTool !== 'polygon' && state !== INITIAL_STATE) {
+      setState(INITIAL_STATE)
+    }
+  }
+
+  // Refs for drag state (rect/circle) — not rendered, so ref is fine
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null)
+  const previewIdRef = useRef<string | null>(null)
+  const overlayRef = useRef<HTMLDivElement>(null)
+
+  // ─── Cleanup on tool switch ─────────────────────────────────────────────
+
+  const cleanupPreview = useCallback(() => {
+    if (previewIdRef.current && engine) {
+      engine.removeShape(previewIdRef.current)
+    }
+    previewIdRef.current = null
+    dragStartRef.current = null
+  }, [engine])
+
+  useEffect(() => {
+    // When tool changes away from a drawing tool, clean up
+    return () => {
+      cleanupPreview()
+    }
+  }, [activeTool, cleanupPreview])
+
+  // ─── Escape / Enter for polygon ──────────────────────────────────────────
+
+  const finishPolygon = useCallback(
+    (pts: { x: number; y: number }[]) => {
+      if (!engine || pts.length < 3) {
+        setState(INITIAL_STATE)
+        return
+      }
+
+      const cx = pts.reduce((sum, p) => sum + p.x, 0) / pts.length
+      const cy = pts.reduce((sum, p) => sum + p.y, 0) / pts.length
+      const relativePoints = pts.map((p) => ({ x: p.x - cx, y: p.y - cy }))
+
+      const groupId = findContainingGroup(engine, cx, cy)
+      const id = crypto.randomUUID()
+
+      engine.addShape({
+        id,
+        type: 'polygon',
+        x: cx,
+        y: cy,
+        points: relativePoints,
+        ...baseShapeProps(),
+        groupId,
+        metadata: pocketMetadata(engine, cx, cy)
+      })
+      engine.select([id])
+      setState(INITIAL_STATE)
+      setActiveTool('select')
+    },
+    [engine, setActiveTool]
+  )
+
+  useEffect(() => {
+    if (activeTool !== 'polygon') return
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        setState(INITIAL_STATE)
+      } else if (e.key === 'Enter') {
+        setState((prev) => {
+          if (prev.polygonVertices.length >= 3) {
+            // Schedule finishPolygon outside setState
+            queueMicrotask(() => finishPolygon(prev.polygonVertices))
+          }
+          return prev
+        })
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [activeTool, finishPolygon])
+
+  // ─── Pointer handlers ─────────────────────────────────────────────────────
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      const overlay = overlayRef.current
+      if (!engine || !overlay || e.button !== 0) return
+      const world = screenToWorld(e.clientX, e.clientY, overlay, engine)
+      const snapped = snapPoint(world, engine)
+
+      if (activeTool === 'rectangle' || activeTool === 'circle') {
+        dragStartRef.current = snapped
+        const id = `preview-${activeTool}-${crypto.randomUUID()}`
+        previewIdRef.current = id
+
+        if (activeTool === 'rectangle') {
+          engine.addShape({
+            id,
+            type: 'rect',
+            x: snapped.x,
+            y: snapped.y,
+            width: 0,
+            height: 0,
+            ...baseShapeProps(),
+            fill: PREVIEW_FILL,
+            stroke: PREVIEW_STROKE,
+            strokeWidth: PREVIEW_STROKE_WIDTH,
+            groupId: null
+          })
+        } else {
+          engine.addShape({
+            id,
+            type: 'circle',
+            x: snapped.x,
+            y: snapped.y,
+            radiusX: 0,
+            radiusY: 0,
+            ...baseShapeProps(),
+            fill: PREVIEW_FILL,
+            stroke: PREVIEW_STROKE,
+            strokeWidth: PREVIEW_STROKE_WIDTH,
+            groupId: null
+          })
+        }
+        ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+      } else if (activeTool === 'polygon') {
+        setState((prev) => {
+          const verts = prev.polygonVertices
+
+          // Close-snap
+          if (verts.length >= 3) {
+            const first = verts[0]
+            const dist = Math.sqrt((snapped.x - first.x) ** 2 + (snapped.y - first.y) ** 2)
+            if (dist < CLOSE_SNAP_DISTANCE) {
+              queueMicrotask(() => finishPolygon(verts))
+              return prev
+            }
+          }
+
+          // Double-click to finish
+          if (e.detail >= 2 && verts.length >= 3) {
+            queueMicrotask(() => finishPolygon(verts))
+            return prev
+          }
+
+          return { ...prev, polygonVertices: [...verts, snapped] }
+        })
+      }
+    },
+    [engine, activeTool, finishPolygon]
+  )
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      const overlay = overlayRef.current
+      if (!engine || !overlay) return
+      const world = screenToWorld(e.clientX, e.clientY, overlay, engine)
+
+      if (
+        (activeTool === 'rectangle' || activeTool === 'circle') &&
+        dragStartRef.current &&
+        previewIdRef.current
+      ) {
+        const snapped = snapPoint(world, engine)
+        const start = dragStartRef.current
+
+        if (activeTool === 'rectangle') {
+          const x = Math.min(start.x, snapped.x)
+          const y = Math.min(start.y, snapped.y)
+          const w = Math.abs(snapped.x - start.x)
+          const h = Math.abs(snapped.y - start.y)
+          engine.updateShape(previewIdRef.current, {
+            x: x + w / 2,
+            y: y + h / 2,
+            width: w,
+            height: h
+          } as Partial<LayoutShape>)
+        } else {
+          const dx = world.x - start.x
+          const dy = world.y - start.y
+          const radius = Math.sqrt(dx * dx + dy * dy)
+          engine.updateShape(previewIdRef.current, {
+            radiusX: radius,
+            radiusY: radius
+          } as Partial<LayoutShape>)
+        }
+      } else if (activeTool === 'polygon') {
+        const snapped = snapPoint(world, engine)
+        setState((prev) => {
+          if (prev.polygonVertices.length === 0) return prev
+          let nearClose = false
+          if (prev.polygonVertices.length >= 3) {
+            const first = prev.polygonVertices[0]
+            const dist = Math.sqrt((snapped.x - first.x) ** 2 + (snapped.y - first.y) ** 2)
+            nearClose = dist < CLOSE_SNAP_DISTANCE
+          }
+          return {
+            ...prev,
+            polygonCursor: snapped,
+            polygonNearClose: nearClose
+          }
+        })
+      }
+    },
+    [engine, activeTool]
+  )
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      const overlay = overlayRef.current
+      if (!engine || !overlay) return
+      if (activeTool !== 'rectangle' && activeTool !== 'circle') return
+      if (!dragStartRef.current || !previewIdRef.current) return
+
+      const world = screenToWorld(e.clientX, e.clientY, overlay, engine)
+      const snapped = snapPoint(world, engine)
+      const start = dragStartRef.current
+
+      // Remove preview
+      engine.removeShape(previewIdRef.current)
+      previewIdRef.current = null
+
+      if (activeTool === 'rectangle') {
+        const w = Math.abs(snapped.x - start.x)
+        const h = Math.abs(snapped.y - start.y)
+        if (w > 2 && h > 2) {
+          const x = Math.min(start.x, snapped.x)
+          const y = Math.min(start.y, snapped.y)
+          const cx = x + w / 2
+          const cy = y + h / 2
+          const groupId = findContainingGroup(engine, cx, cy)
+          const id = crypto.randomUUID()
+          engine.addShape({
+            id,
+            type: 'rect',
+            x: cx,
+            y: cy,
+            width: w,
+            height: h,
+            ...baseShapeProps(),
+            groupId,
+            metadata: pocketMetadata(engine, cx, cy)
+          })
+          engine.select([id])
+          setActiveTool('select')
+        }
+      } else {
+        const dx = world.x - start.x
+        const dy = world.y - start.y
+        const radius = Math.sqrt(dx * dx + dy * dy)
+        if (radius > 2) {
+          const groupId = findContainingGroup(engine, start.x, start.y)
+          const id = crypto.randomUUID()
+          engine.addShape({
+            id,
+            type: 'circle',
+            x: start.x,
+            y: start.y,
+            radiusX: radius,
+            radiusY: radius,
+            ...baseShapeProps(),
+            groupId,
+            metadata: pocketMetadata(engine, start.x, start.y)
+          })
+          engine.select([id])
+          setActiveTool('select')
+        }
+      }
+
+      dragStartRef.current = null
+    },
+    [engine, activeTool, setActiveTool]
+  )
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  if (!activeTool || activeTool === 'select' || !engine) return null
+
+  return (
+    <div
+      ref={overlayRef}
+      className="absolute inset-0 z-20"
+      style={{ cursor: 'crosshair' }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+    >
+      {activeTool === 'polygon' && state.polygonVertices.length > 0 && (
+        <PolygonPreviewSvg
+          vertices={state.polygonVertices}
+          cursor={state.polygonCursor}
+          isNearClose={state.polygonNearClose}
+          viewport={viewport}
+        />
+      )}
+    </div>
+  )
+}
+
+// ─── SVG Overlay for polygon preview ────────────────────────────────────────
+
+function PolygonPreviewSvg({
+  vertices,
+  cursor,
+  isNearClose,
+  viewport
+}: {
+  vertices: { x: number; y: number }[]
+  cursor: { x: number; y: number } | null
+  isNearClose: boolean
+  viewport: { panX: number; panY: number; zoom: number }
+}): React.JSX.Element {
+  const toScreen = (wx: number, wy: number): { sx: number; sy: number } => ({
+    sx: wx * viewport.zoom - viewport.panX,
+    sy: wy * viewport.zoom - viewport.panY
+  })
+
+  const screenVerts = vertices.map((v) => toScreen(v.x, v.y))
+  const cursorScreen = cursor ? toScreen(cursor.x, cursor.y) : null
+
+  const allPoints = [...screenVerts, ...(cursorScreen ? [cursorScreen] : [])]
+  const pathData =
+    allPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.sx} ${p.sy}`).join(' ') +
+    (isNearClose ? ' Z' : '')
+
+  return (
+    <svg className="absolute inset-0 pointer-events-none" width="100%" height="100%">
+      {allPoints.length >= 3 && <path d={pathData} fill={PREVIEW_FILL} stroke="none" />}
+      <path
+        d={pathData}
+        fill="none"
+        stroke={PREVIEW_STROKE}
+        strokeWidth={PREVIEW_STROKE_WIDTH}
+        strokeDasharray="4 3"
+      />
+      {screenVerts.map((p, i) => (
+        <circle
+          key={i}
+          cx={p.sx}
+          cy={p.sy}
+          r={i === 0 && isNearClose ? 6 : 3}
+          fill={i === 0 && isNearClose ? 'rgba(168, 85, 247, 0.3)' : SHAPE_STROKE}
+          stroke={i === 0 && isNearClose ? SHAPE_STROKE : 'none'}
+          strokeWidth={1.5}
+        />
+      ))}
+    </svg>
+  )
+}

--- a/src/renderer/src/components/Navbar.tsx
+++ b/src/renderer/src/components/Navbar.tsx
@@ -22,6 +22,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import PreferencesModal from '@/components/settings/PreferencesModal'
 import NewProjectDialog from '@/components/settings/NewProjectDialog'
 import { useProject } from '@/hooks/useProject'
+import { useUndoRedo } from '@/hooks/useUndoRedo'
 import { useAppMode } from '@/hooks/useAppMode'
 import {
   SquareDashedIcon,
@@ -120,6 +121,7 @@ function AppMenubar({
 }) {
   const { project, saveProject, saveProjectAs, loadProject, recentProjects, loadRecentProjects } =
     useProject()
+  const { undo, redo, canUndo, canRedo } = useUndoRedo()
 
   useEffect(() => {
     loadRecentProjects()
@@ -201,11 +203,11 @@ function AppMenubar({
       <MenubarMenu>
         <MenubarTrigger>Edit</MenubarTrigger>
         <MenubarContent onCloseAutoFocus={(e) => e.preventDefault()}>
-          <MenubarItem disabled>
+          <MenubarItem disabled={!canUndo} onSelect={undo}>
             Undo
             <MenubarShortcut>Cmd+Z</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem disabled>
+          <MenubarItem disabled={!canRedo} onSelect={redo}>
             Redo
             <MenubarShortcut>Cmd+Shift+Z</MenubarShortcut>
           </MenubarItem>

--- a/src/renderer/src/components/Viewport.tsx
+++ b/src/renderer/src/components/Viewport.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useCallback, useRef, useState } from 'react'
 import { useAppMode } from '@/hooks/useAppMode'
 import { useProject } from '@/hooks/useProject'
+import { useUndoRedo } from '@/hooks/useUndoRedo'
 import ReviewCanvas from './review/ReviewCanvas'
 import {
   LayoutEngineProvider,
   LayoutEngineCanvas,
   useLayoutEngineContext,
-  useEngineUndoRedo,
   useEngineState,
   useProjectEngineSync,
   useBinArtwork
@@ -39,7 +39,7 @@ const STAR_PATH =
 
 function LayoutViewport(): React.JSX.Element {
   const { engine } = useLayoutEngineContext()
-  const { canUndo, canRedo } = useEngineUndoRedo(engine)
+  const { canUndo, canRedo } = useUndoRedo()
   const { tick } = useEngineState()
   useProjectEngineSync()
 

--- a/src/renderer/src/components/Viewport.tsx
+++ b/src/renderer/src/components/Viewport.tsx
@@ -7,12 +7,15 @@ import {
   LayoutEngineProvider,
   LayoutEngineCanvas,
   useLayoutEngineContext,
+  useEngineUndoRedo,
   useEngineState,
   useProjectEngineSync,
   useBinArtwork
 } from '@/layout-engine'
 import DrawingToolLayer from './DrawingToolLayer'
 import HintCard from './HintCard'
+
+const MOD_KEY = navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'
 
 // ─── Sandbox helpers (only used in sandbox mode) ────────────────────────────
 
@@ -39,7 +42,9 @@ const STAR_PATH =
 
 function LayoutViewport(): React.JSX.Element {
   const { engine } = useLayoutEngineContext()
-  const { canUndo, canRedo } = useUndoRedo()
+  useEngineUndoRedo(engine) // syncs canUndo/canRedo to useUndoRedo store
+  const canUndo = useUndoRedo((s) => s.canUndo)
+  const canRedo = useUndoRedo((s) => s.canRedo)
   const { tick } = useEngineState()
   useProjectEngineSync()
 
@@ -85,7 +90,7 @@ function LayoutViewport(): React.JSX.Element {
   return (
     <>
       <div className={statusClass}>
-        {canUndo ? 'Ctrl+Z undo' : ''} {canRedo ? '| Ctrl+Shift+Z redo' : ''}
+        {canUndo ? `${MOD_KEY}+Z undo` : ''} {canRedo ? `| ${MOD_KEY}+Shift+Z redo` : ''}
       </div>
     </>
   )

--- a/src/renderer/src/components/Viewport.tsx
+++ b/src/renderer/src/components/Viewport.tsx
@@ -11,6 +11,7 @@ import {
   useProjectEngineSync,
   useBinArtwork
 } from '@/layout-engine'
+import DrawingToolLayer from './DrawingToolLayer'
 import HintCard from './HintCard'
 
 // ─── Sandbox helpers (only used in sandbox mode) ────────────────────────────
@@ -387,6 +388,7 @@ export default function Viewport(): React.JSX.Element {
       >
         <LayoutEngineCanvas />
         {mode === 'layout' && <LayoutViewport />}
+        {mode === 'layout' && <DrawingToolLayer />}
       </div>
       <div className={mode === 'review' ? 'h-full' : 'hidden'}>
         <ReviewCanvas bakeResults={bakeResults} baseUnit={baseUnit} />

--- a/src/renderer/src/hooks/useProject.ts
+++ b/src/renderer/src/hooks/useProject.ts
@@ -57,6 +57,13 @@ interface ProjectState {
   // Layout snapshot (synced from engine)
   setLayoutSnapshot: (snapshot: LayoutSnapshotData) => void
 
+  /**
+   * Register a callback that runs before every save operation.
+   * Used by useProjectEngineSync to capture the engine snapshot into the project.
+   * Returns an unsubscribe function.
+   */
+  registerBeforeSave: (cb: () => void) => () => void
+
   // Bake results
   setBakeResult: (binId: string, result: BakeResult | null) => void
   clearAllBakeResults: () => void
@@ -85,6 +92,10 @@ function loadSession(): SessionData {
 function saveSession(state: SessionData): void {
   sessionStorage.setItem(SESSION_KEY, JSON.stringify(state))
 }
+
+// ─── Before-save callbacks ───────────────────────────────────
+
+const beforeSaveCallbacks = new Set<() => void>()
 
 // ─── Store ──────────────────────────────────────────────────
 
@@ -124,7 +135,15 @@ const useProjectStore = create<ProjectState>()((set, get) => {
 
     // ── File operations ──
 
+    registerBeforeSave: (cb) => {
+      beforeSaveCallbacks.add(cb)
+      return () => {
+        beforeSaveCallbacks.delete(cb)
+      }
+    },
+
     saveProject: async (targetPath) => {
+      for (const cb of beforeSaveCallbacks) cb()
       const state = get()
       if (!state.project) {
         set({ error: 'No project to save' })
@@ -151,6 +170,7 @@ const useProjectStore = create<ProjectState>()((set, get) => {
     },
 
     saveProjectAs: async () => {
+      for (const cb of beforeSaveCallbacks) cb()
       const state = get()
       if (!state.project) {
         set({ error: 'No project to save' })

--- a/src/renderer/src/hooks/useUndoRedo.ts
+++ b/src/renderer/src/hooks/useUndoRedo.ts
@@ -1,21 +1,17 @@
-import { createContext, useContext } from 'react'
+import { create } from 'zustand'
 
-export interface UndoRedoState {
-  undo: () => void
-  redo: () => void
+interface UndoRedoStore {
   canUndo: boolean
   canRedo: boolean
+  undo: () => void
+  redo: () => void
 }
 
 const noop = (): void => {}
 
-export const UndoRedoCtx = createContext<UndoRedoState>({
-  undo: noop,
-  redo: noop,
+export const useUndoRedo = create<UndoRedoStore>()(() => ({
   canUndo: false,
-  canRedo: false
-})
-
-export function useUndoRedo(): UndoRedoState {
-  return useContext(UndoRedoCtx)
-}
+  canRedo: false,
+  undo: noop,
+  redo: noop
+}))

--- a/src/renderer/src/hooks/useUndoRedo.ts
+++ b/src/renderer/src/hooks/useUndoRedo.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react'
+
+export interface UndoRedoState {
+  undo: () => void
+  redo: () => void
+  canUndo: boolean
+  canRedo: boolean
+}
+
+const noop = (): void => {}
+
+export const UndoRedoCtx = createContext<UndoRedoState>({
+  undo: noop,
+  redo: noop,
+  canUndo: false,
+  canRedo: false
+})
+
+export function useUndoRedo(): UndoRedoState {
+  return useContext(UndoRedoCtx)
+}

--- a/src/renderer/src/layout-engine/fabric-engine.ts
+++ b/src/renderer/src/layout-engine/fabric-engine.ts
@@ -1244,12 +1244,8 @@ export class FabricEngine implements LayoutEngine {
             }
           }
         }
-      } else if (gridEnabled) {
-        // Snap shape center to grid
-        const left = Math.round((obj.left ?? 0) / size) * size
-        const top = Math.round((obj.top ?? 0) / size) * size
-        obj.set({ left, top })
       }
+      // Shapes do not snap to the bin grid — they move freely.
       obj.setCoords()
     })
   }

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -241,28 +241,9 @@ export class KonvaEngine implements LayoutEngine {
     this.shapeMap.set(shape.id, { ...shape })
     this.konvaMap.set(shape.id, node)
 
-    node.on('dragmove', () => {
-      if (!this.gridConfig.enabled) return
-      const selectedNodes = this.transformer?.nodes() ?? []
-      if (selectedNodes.length > 1) return // defer to dragend
-
-      const size = this.gridConfig.size
-      node.position({
-        x: Math.round(node.x() / size) * size,
-        y: Math.round(node.y() / size) * size
-      })
-      this.transformer?.forceUpdate()
-    })
+    // Shapes move freely — no grid snap (only bins snap to the bin grid).
 
     node.on('dragend', () => {
-      if (this.gridConfig.enabled) {
-        const size = this.gridConfig.size
-        node.position({
-          x: Math.round(node.x() / size) * size,
-          y: Math.round(node.y() / size) * size
-        })
-        this.transformer?.forceUpdate()
-      }
       const data = this.shapeMap.get(shape.id)
       if (data) {
         data.x = node.x()

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -24,6 +24,27 @@ const GRID_EXTENT = 10000
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 
+/**
+ * Compute the bounding-box center of a polygon's points.
+ * Used to set Konva.Line offset so that x,y = bbox center, matching
+ * Fabric's originX/Y:'center' convention (which uses bbox center,
+ * NOT geometric centroid).
+ */
+function polygonBboxCenter(points: { x: number; y: number }[]): { x: number; y: number } {
+  if (points.length === 0) return { x: 0, y: 0 }
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+  for (const p of points) {
+    if (p.x < minX) minX = p.x
+    if (p.x > maxX) maxX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.y > maxY) maxY = p.y
+  }
+  return { x: (minX + maxX) / 2, y: (minY + maxY) / 2 }
+}
+
 function layoutShapeToKonva(shape: LayoutShape): Konva.Shape {
   let node: Konva.Shape
 
@@ -45,12 +66,17 @@ function layoutShapeToKonva(shape: LayoutShape): Konva.Shape {
         radiusY: shape.radiusY
       })
       break
-    case 'polygon':
+    case 'polygon': {
+      // Offset so x,y = bbox center (matches Fabric's originX/Y:'center')
+      const c = polygonBboxCenter(shape.points)
       node = new Konva.Line({
         points: shape.points.flatMap((p) => [p.x, p.y]),
-        closed: true
+        closed: true,
+        offsetX: c.x,
+        offsetY: c.y
       })
       break
+    }
     case 'svgPath':
       node = new Konva.Path({
         data: shape.pathData

--- a/src/renderer/src/layout-engine/useBinArtwork.ts
+++ b/src/renderer/src/layout-engine/useBinArtwork.ts
@@ -92,6 +92,19 @@ export function useBinArtwork(
   const prevKeysRef = useRef<Map<string, string>>(new Map())
   const prevEngineRef = useRef<LayoutEngine | null>(null)
 
+  // Clear cache when groups are removed (e.g. during loadSnapshot/undo).
+  // loadSnapshot removes all groups then recreates them — without this,
+  // the cache sees identical keys and skips re-applying decorations to
+  // the new canvas objects.
+  useEffect(() => {
+    if (!engine) return
+    return engine.on('groupChanged', ({ childIds }) => {
+      if (childIds.length === 0) {
+        prevKeysRef.current = new Map()
+      }
+    })
+  }, [engine])
+
   useEffect(() => {
     // Reset cache when engine instance changes (e.g., engine switch)
     if (engine !== prevEngineRef.current) {

--- a/src/renderer/src/layout-engine/useEngineUndoRedo.ts
+++ b/src/renderer/src/layout-engine/useEngineUndoRedo.ts
@@ -80,7 +80,10 @@ export function useEngineUndoRedo(engine: LayoutEngine | null): {
       engine.on('shapeCreated', debouncedPush),
       engine.on('shapeDeleted', debouncedPush),
       engine.on('shapeMoved', debouncedPush),
-      engine.on('shapeResized', debouncedPush)
+      engine.on('shapeResized', debouncedPush),
+      engine.on('groupChanged', debouncedPush),
+      engine.on('groupMoved', debouncedPush),
+      engine.on('groupResized', debouncedPush)
     ]
 
     return () => {

--- a/src/renderer/src/layout-engine/useEngineUndoRedo.ts
+++ b/src/renderer/src/layout-engine/useEngineUndoRedo.ts
@@ -121,12 +121,12 @@ export function useEngineUndoRedo(engine: LayoutEngine | null): {
 
       const mod = e.metaKey || e.ctrlKey
 
-      if (mod && e.key === 'z' && !e.shiftKey) {
+      if (mod && e.code === 'KeyZ' && !e.shiftKey) {
         e.preventDefault()
         undo()
         return
       }
-      if (mod && (e.key === 'Z' || e.key === 'y') && (e.shiftKey || e.key === 'y')) {
+      if (mod && ((e.code === 'KeyZ' && e.shiftKey) || e.code === 'KeyY')) {
         e.preventDefault()
         redo()
       }

--- a/src/renderer/src/layout-engine/useEngineUndoRedo.ts
+++ b/src/renderer/src/layout-engine/useEngineUndoRedo.ts
@@ -3,12 +3,16 @@ import { useUndoRedo } from '@/hooks/useUndoRedo'
 import type { LayoutEngine } from './interface'
 
 const MAX_UNDO = 50
+const DEBOUNCE_MS = 300
 
 /**
  * Engine-snapshot-based undo/redo.
  *
- * Maintains an undo stack of JSON-serialized snapshots, debounce-pushes
- * on shape events, and provides undo/redo callbacks + keyboard shortcuts.
+ * Captures undo snapshots at interaction boundaries:
+ * - shapeMoved, shapeResized, groupMoved, groupResized fire once at the
+ *   end of a drag/resize in both engines → push immediately.
+ * - shapeCreated, shapeDeleted, groupChanged are discrete actions but may
+ *   fire in rapid bursts (e.g. loadSnapshot) → push with short debounce.
  *
  * Also syncs canUndo/canRedo/undo/redo to the useUndoRedo zustand store
  * so the Navbar and other distant consumers can read undo/redo state.
@@ -22,7 +26,7 @@ export function useEngineUndoRedo(engine: LayoutEngine | null): {
   const undoStackRef = useRef<string[]>([])
   const redoStackRef = useRef<string[]>([])
   const isUndoingRef = useRef(false)
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [canUndo, setCanUndo] = useState(false)
   const [canRedo, setCanRedo] = useState(false)
 
@@ -31,7 +35,7 @@ export function useEngineUndoRedo(engine: LayoutEngine | null): {
     setCanRedo(redoStackRef.current.length > 0)
   }, [])
 
-  const pushUndo = useCallback(() => {
+  const pushSnapshot = useCallback(() => {
     if (!engine || isUndoingRef.current) return
     const json = JSON.stringify(engine.toSnapshot())
     const stack = undoStackRef.current
@@ -41,6 +45,11 @@ export function useEngineUndoRedo(engine: LayoutEngine | null): {
     redoStackRef.current = []
     syncCounts()
   }, [engine, syncCounts])
+
+  const debouncedPush = useCallback(() => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+    debounceTimerRef.current = setTimeout(pushSnapshot, DEBOUNCE_MS)
+  }, [pushSnapshot])
 
   const undo = useCallback(() => {
     if (!engine || undoStackRef.current.length < 2) return
@@ -76,30 +85,33 @@ export function useEngineUndoRedo(engine: LayoutEngine | null): {
     syncCounts()
   }, [engine, syncCounts])
 
-  // Auto-push undo snapshots on shape changes (debounced)
+  // Subscribe to engine events for undo snapshot capture
   useEffect(() => {
     if (!engine) return
 
-    const debouncedPush = (): void => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
-      saveTimerRef.current = setTimeout(pushUndo, 500)
-    }
+    // Interaction-end events fire once per completed drag/resize.
+    // Push immediately — no debounce needed.
+    const interactionUnsubs = [
+      engine.on('shapeMoved', pushSnapshot),
+      engine.on('shapeResized', pushSnapshot),
+      engine.on('groupMoved', pushSnapshot),
+      engine.on('groupResized', pushSnapshot)
+    ]
 
-    const unsubs = [
+    // Discrete/bulk events may fire in bursts (e.g. loadSnapshot removes
+    // then recreates everything). Debounce to coalesce into one snapshot.
+    const discreteUnsubs = [
       engine.on('shapeCreated', debouncedPush),
       engine.on('shapeDeleted', debouncedPush),
-      engine.on('shapeMoved', debouncedPush),
-      engine.on('shapeResized', debouncedPush),
-      engine.on('groupChanged', debouncedPush),
-      engine.on('groupMoved', debouncedPush),
-      engine.on('groupResized', debouncedPush)
+      engine.on('groupChanged', debouncedPush)
     ]
 
     return () => {
-      unsubs.forEach((u) => u())
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      interactionUnsubs.forEach((u) => u())
+      discreteUnsubs.forEach((u) => u())
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
     }
-  }, [engine, pushUndo])
+  }, [engine, pushSnapshot, debouncedPush])
 
   // Keyboard shortcuts: Ctrl+Z undo, Ctrl+Shift+Z / Ctrl+Y redo
   useEffect(() => {

--- a/src/renderer/src/layout-engine/useEngineUndoRedo.ts
+++ b/src/renderer/src/layout-engine/useEngineUndoRedo.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useUndoRedo } from '@/hooks/useUndoRedo'
 import type { LayoutEngine } from './interface'
 
 const MAX_UNDO = 50
@@ -8,6 +9,9 @@ const MAX_UNDO = 50
  *
  * Maintains an undo stack of JSON-serialized snapshots, debounce-pushes
  * on shape events, and provides undo/redo callbacks + keyboard shortcuts.
+ *
+ * Also syncs canUndo/canRedo/undo/redo to the useUndoRedo zustand store
+ * so the Navbar and other distant consumers can read undo/redo state.
  */
 export function useEngineUndoRedo(engine: LayoutEngine | null): {
   undo: () => void
@@ -57,6 +61,11 @@ export function useEngineUndoRedo(engine: LayoutEngine | null): {
     syncCounts()
     isUndoingRef.current = false
   }, [engine, syncCounts])
+
+  // Sync state to zustand store so Navbar can read it
+  useEffect(() => {
+    useUndoRedo.setState({ canUndo, canRedo, undo, redo })
+  }, [canUndo, canRedo, undo, redo])
 
   // Initialize baseline snapshot when engine mounts
   useEffect(() => {

--- a/src/renderer/src/layout-engine/useProjectEngineSync.ts
+++ b/src/renderer/src/layout-engine/useProjectEngineSync.ts
@@ -29,17 +29,15 @@ const SYNC_DEBOUNCE_MS = 1000
 /**
  * Syncs the layout engine snapshot with the project store.
  *
- * - Before save: registers a callback that captures engine.toSnapshot() →
- *   project.layoutSnapshot automatically whenever saveProject/saveProjectAs
- *   is called (from Navbar or anywhere else).
+ * Responsibilities:
+ * - Before save: captures engine.toSnapshot() → project.layoutSnapshot
+ *   via registerBeforeSave, so any save path gets current engine state.
  * - On mutation: debounce-syncs the snapshot to the project store so that
- *   session persistence (sessionStorage) always has a recent layout.
+ *   sessionStorage always has a recent layout (survives page refresh).
+ * - On mutation: marks the project as modified (isModified = true) so
+ *   the "Unsaved" badge shows. Suppressed during project load to avoid
+ *   false positives.
  * - After load: reads project.layoutSnapshot → engine.loadSnapshot()
- *
- * The LayoutSnapshotData (shared/) and LayoutSnapshot (renderer/) types are
- * structurally equivalent but use slightly different shape representations
- * (flat vs discriminated union). The casts here are safe because both encode
- * the same data — just with different TypeScript narrowing strategies.
  */
 export function useProjectEngineSync(): void {
   const engine = useLayoutEngine()
@@ -47,6 +45,11 @@ export function useProjectEngineSync(): void {
   const project = useProject((s) => s.project)
   const loadedProjectRef = useRef<string | null>(null)
   const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // True during engine.loadSnapshot() calls triggered by project load.
+  // Engine events fire synchronously during loadSnapshot, so this ref
+  // suppresses the isModified flag for those events.
+  const isRestoringRef = useRef(false)
 
   // On project load: restore engine state from layoutSnapshot.
   // Only runs when a NEW project is loaded (different createdAt), not on engine switches.
@@ -62,7 +65,9 @@ export function useProjectEngineSync(): void {
       return
     }
 
+    isRestoringRef.current = true
     engine.loadSnapshot(project.layoutSnapshot as unknown as LayoutSnapshot)
+    isRestoringRef.current = false
   }, [engine, project?.layoutSnapshot, projectId])
 
   const captureSnapshot = useCallback((): void => {
@@ -80,22 +85,30 @@ export function useProjectEngineSync(): void {
 
   // Debounce-sync engine state to project store on mutations so
   // sessionStorage always has a recent layout (survives page refresh).
+  // Also mark project as modified unless we're restoring from a file load.
   useEffect(() => {
     if (!engine) return
 
-    const debouncedSync = (): void => {
+    const onMutation = (): void => {
+      // Mark as modified for user-initiated changes (not during project load).
+      // Undo/redo also marks modified — the state differs from the saved file.
+      if (!isRestoringRef.current) {
+        useProject.setState({ isModified: true })
+      }
+
+      // Debounce the session snapshot sync
       if (syncTimerRef.current) clearTimeout(syncTimerRef.current)
       syncTimerRef.current = setTimeout(captureSnapshot, SYNC_DEBOUNCE_MS)
     }
 
     const unsubs = [
-      engine.on('shapeCreated', debouncedSync),
-      engine.on('shapeDeleted', debouncedSync),
-      engine.on('shapeMoved', debouncedSync),
-      engine.on('shapeResized', debouncedSync),
-      engine.on('groupChanged', debouncedSync),
-      engine.on('groupMoved', debouncedSync),
-      engine.on('groupResized', debouncedSync)
+      engine.on('shapeCreated', onMutation),
+      engine.on('shapeDeleted', onMutation),
+      engine.on('shapeMoved', onMutation),
+      engine.on('shapeResized', onMutation),
+      engine.on('groupChanged', onMutation),
+      engine.on('groupMoved', onMutation),
+      engine.on('groupResized', onMutation)
     ]
 
     return () => {

--- a/src/renderer/src/layout-engine/useProjectEngineSync.ts
+++ b/src/renderer/src/layout-engine/useProjectEngineSync.ts
@@ -27,7 +27,9 @@ function isValidSnapshot(data: unknown): data is LayoutSnapshot {
 /**
  * Syncs the layout engine snapshot with the project store.
  *
- * - Before save: captures engine.toSnapshot() → project.layoutSnapshot
+ * - Before save: registers a callback that captures engine.toSnapshot() →
+ *   project.layoutSnapshot automatically whenever saveProject/saveProjectAs
+ *   is called (from Navbar or anywhere else).
  * - After load: reads project.layoutSnapshot → engine.loadSnapshot()
  *
  * The LayoutSnapshotData (shared/) and LayoutSnapshot (renderer/) types are
@@ -35,12 +37,9 @@ function isValidSnapshot(data: unknown): data is LayoutSnapshot {
  * (flat vs discriminated union). The casts here are safe because both encode
  * the same data — just with different TypeScript narrowing strategies.
  */
-export function useProjectEngineSync(): {
-  saveWithSnapshot: (targetPath?: string) => Promise<boolean>
-  saveAsWithSnapshot: () => Promise<boolean>
-} {
+export function useProjectEngineSync(): void {
   const engine = useLayoutEngine()
-  const { saveProject, saveProjectAs, setLayoutSnapshot } = useProject()
+  const { setLayoutSnapshot, registerBeforeSave } = useProject()
   const project = useProject((s) => s.project)
   const loadedProjectRef = useRef<string | null>(null)
 
@@ -68,18 +67,9 @@ export function useProjectEngineSync(): {
     setLayoutSnapshot(snapshot as unknown as LayoutSnapshotData)
   }, [engine, setLayoutSnapshot])
 
-  const saveWithSnapshot = useCallback(
-    async (targetPath?: string): Promise<boolean> => {
-      captureSnapshot()
-      return saveProject(targetPath)
-    },
-    [captureSnapshot, saveProject]
-  )
-
-  const saveAsWithSnapshot = useCallback(async (): Promise<boolean> => {
-    captureSnapshot()
-    return saveProjectAs()
-  }, [captureSnapshot, saveProjectAs])
-
-  return { saveWithSnapshot, saveAsWithSnapshot }
+  // Register snapshot capture as a before-save callback so ANY save path
+  // (Navbar, keyboard shortcut, etc.) captures engine state automatically.
+  useEffect(() => {
+    return registerBeforeSave(captureSnapshot)
+  }, [registerBeforeSave, captureSnapshot])
 }

--- a/src/renderer/src/layout-engine/useProjectEngineSync.ts
+++ b/src/renderer/src/layout-engine/useProjectEngineSync.ts
@@ -24,12 +24,16 @@ function isValidSnapshot(data: unknown): data is LayoutSnapshot {
   return true
 }
 
+const SYNC_DEBOUNCE_MS = 1000
+
 /**
  * Syncs the layout engine snapshot with the project store.
  *
  * - Before save: registers a callback that captures engine.toSnapshot() →
  *   project.layoutSnapshot automatically whenever saveProject/saveProjectAs
  *   is called (from Navbar or anywhere else).
+ * - On mutation: debounce-syncs the snapshot to the project store so that
+ *   session persistence (sessionStorage) always has a recent layout.
  * - After load: reads project.layoutSnapshot → engine.loadSnapshot()
  *
  * The LayoutSnapshotData (shared/) and LayoutSnapshot (renderer/) types are
@@ -42,6 +46,7 @@ export function useProjectEngineSync(): void {
   const { setLayoutSnapshot, registerBeforeSave } = useProject()
   const project = useProject((s) => s.project)
   const loadedProjectRef = useRef<string | null>(null)
+  const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // On project load: restore engine state from layoutSnapshot.
   // Only runs when a NEW project is loaded (different createdAt), not on engine switches.
@@ -72,4 +77,28 @@ export function useProjectEngineSync(): void {
   useEffect(() => {
     return registerBeforeSave(captureSnapshot)
   }, [registerBeforeSave, captureSnapshot])
+
+  // Debounce-sync engine state to project store on mutations so
+  // sessionStorage always has a recent layout (survives page refresh).
+  useEffect(() => {
+    if (!engine) return
+
+    const debouncedSync = (): void => {
+      if (syncTimerRef.current) clearTimeout(syncTimerRef.current)
+      syncTimerRef.current = setTimeout(captureSnapshot, SYNC_DEBOUNCE_MS)
+    }
+
+    const unsubs = [
+      engine.on('shapeCreated', debouncedSync),
+      engine.on('shapeDeleted', debouncedSync),
+      engine.on('shapeMoved', debouncedSync),
+      engine.on('shapeResized', debouncedSync),
+      engine.on('groupChanged', debouncedSync)
+    ]
+
+    return () => {
+      unsubs.forEach((u) => u())
+      if (syncTimerRef.current) clearTimeout(syncTimerRef.current)
+    }
+  }, [engine, captureSnapshot])
 }

--- a/src/renderer/src/layout-engine/useProjectEngineSync.ts
+++ b/src/renderer/src/layout-engine/useProjectEngineSync.ts
@@ -93,7 +93,9 @@ export function useProjectEngineSync(): void {
       engine.on('shapeDeleted', debouncedSync),
       engine.on('shapeMoved', debouncedSync),
       engine.on('shapeResized', debouncedSync),
-      engine.on('groupChanged', debouncedSync)
+      engine.on('groupChanged', debouncedSync),
+      engine.on('groupMoved', debouncedSync),
+      engine.on('groupResized', debouncedSync)
     ]
 
     return () => {


### PR DESCRIPTION
## Summary

Fixes #252 — polygons shift position when switching between Fabric and Konva engines.

- **Root cause**: Fabric positions polygons by bounding-box center (`originX/Y: 'center'`), but Konva's `Line` node had no offset set, so `x, y` was a raw translation from the polygon's local coordinate origin — a different point than Fabric's bbox center.
- **Fix**: Compute the bbox center from polygon points and set `offsetX`/`offsetY` on the Konva `Line` node at creation time. Now both engines use the same "x,y = bbox center" convention, so round-tripping through `toSnapshot()`/`loadSnapshot()` preserves position exactly.

## Test plan

- [ ] Create a polygon shape (triangle, hexagon) in Fabric engine
- [ ] Switch to Konva engine — polygon should remain in the same position
- [ ] Switch back — no drift
- [ ] Save and reload project with polygons — positions preserved
- [ ] Drag polygons, undo/redo — positions correct in both engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)