### PR TITLE
fix(core): normalize polygon position across Fabric/Konva engines

### DIFF
--- a/src/renderer/src/layout-engine/__tests__/layout-engine.contract.test.ts
+++ b/src/renderer/src/layout-engine/__tests__/layout-engine.contract.test.ts
@@ -556,6 +556,45 @@ describe('Cross-engine snapshot roundtrip', () => {
     konvaEngine.dispose()
   })
 
+  it('Fabric → Konva → Fabric: polygon position preserved (bbox center convention)', () => {
+    // Asymmetric triangle: bbox center = (50, 40), centroid ≠ bbox center.
+    // Regression test for #252 — polygon drift when switching engines.
+    const fabricEngine = createLayoutEngine('fabric')
+    fabricEngine.mount(container)
+
+    fabricEngine.addShape(makePolygon({ id: 'asym', x: 200, y: 150 }))
+
+    const origShape = fabricEngine.getShape('asym')!
+    const origX = origShape.x
+    const origY = origShape.y
+
+    // Fabric → Konva
+    const snap1 = fabricEngine.toSnapshot()
+    fabricEngine.dispose()
+
+    const konvaEngine = createLayoutEngine('konva')
+    konvaEngine.mount(container)
+    konvaEngine.loadSnapshot(snap1)
+
+    const konvaShape = konvaEngine.getShape('asym')!
+    expect(konvaShape.x).toBeCloseTo(origX, 1)
+    expect(konvaShape.y).toBeCloseTo(origY, 1)
+
+    // Konva → Fabric
+    const snap2 = konvaEngine.toSnapshot()
+    konvaEngine.dispose()
+
+    const fabricEngine2 = createLayoutEngine('fabric')
+    fabricEngine2.mount(container)
+    fabricEngine2.loadSnapshot(snap2)
+
+    const finalShape = fabricEngine2.getShape('asym')!
+    expect(finalShape.x).toBeCloseTo(origX, 1)
+    expect(finalShape.y).toBeCloseTo(origY, 1)
+
+    fabricEngine2.dispose()
+  })
+
   it('Konva → Fabric: snapshot preserves all shapes and groups', () => {
     const konvaEngine = createLayoutEngine('konva')
     konvaEngine.mount(container)

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -24,6 +24,26 @@ const GRID_EXTENT = 10000
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 
+/**
+ * Compute the bounding-box center of a polygon's points.
+ * Used to set Konva.Line offset so that x,y = bbox center, matching
+ * Fabric's originX/Y:'center' convention.
+ */
+function polygonBboxCenter(points: { x: number; y: number }[]): { x: number; y: number } {
+  if (points.length === 0) return { x: 0, y: 0 }
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+  for (const p of points) {
+    if (p.x < minX) minX = p.x
+    if (p.x > maxX) maxX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.y > maxY) maxY = p.y
+  }
+  return { x: (minX + maxX) / 2, y: (minY + maxY) / 2 }
+}
+
 function layoutShapeToKonva(shape: LayoutShape): Konva.Shape {
   let node: Konva.Shape
 
@@ -45,12 +65,16 @@ function layoutShapeToKonva(shape: LayoutShape): Konva.Shape {
         radiusY: shape.radiusY
       })
       break
-    case 'polygon':
+    case 'polygon': {
+      const c = polygonBboxCenter(shape.points)
       node = new Konva.Line({
         points: shape.points.flatMap((p) => [p.x, p.y]),
-        closed: true
+        closed: true,
+        offsetX: c.x,
+        offsetY: c.y
       })
       break
+    }
     case 'svgPath':
       node = new Konva.Path({
         data: shape.pathData


### PR DESCRIPTION
## Summary

Fixes #252 — polygons shift position when switching between Fabric and Konva engines.

- **Root cause**: Fabric positions polygons by bounding-box center (`originX/Y: 'center'`), but Konva's `Line` node had no offset set, so `x, y` was a raw translation from the polygon's local coordinate origin — a different point than Fabric's bbox center.
- **Fix**: Compute the bbox center from polygon points and set `offsetX`/`offsetY` on the Konva `Line` node at creation time. Now both engines use the same "x,y = bbox center" convention, so round-tripping through `toSnapshot()`/`loadSnapshot()` preserves position exactly.
- **Regression test**: Added cross-engine roundtrip test (Fabric → Konva → Fabric) asserting polygon `x`/`y` are preserved for an asymmetric triangle where centroid ≠ bbox center.

## Test plan

- [ ] Create a polygon shape (triangle, hexagon) in Fabric engine
- [ ] Switch to Konva engine — polygon should remain in the same position
- [ ] Switch back — no drift
- [ ] Save and reload project with polygons — positions preserved
- [ ] Drag polygons, undo/redo — positions correct in both engines
- [ ] New cross-engine roundtrip test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)