### PR TITLE
fix(core): Konva multi-drag snap — shapes follow bin snap

### DIFF
--- a/src/renderer/src/layout-engine/collision.ts
+++ b/src/renderer/src/layout-engine/collision.ts
@@ -48,10 +48,12 @@ function aabbOverlap(a: AABB, b: AABB): boolean {
 export function checkGroupCollision(
   proposed: AABB,
   groupId: string,
-  allGroups: LayoutGroup[]
+  allGroups: LayoutGroup[],
+  excludeIds?: Set<string>
 ): string | null {
   for (const other of allGroups) {
     if (other.id === groupId) continue
+    if (excludeIds?.has(other.id)) continue
     if (aabbOverlap(proposed, other)) return other.id
   }
   return null

--- a/src/renderer/src/layout-engine/fabric-engine.ts
+++ b/src/renderer/src/layout-engine/fabric-engine.ts
@@ -715,6 +715,10 @@ export class FabricEngine implements LayoutEngine {
     return this.interacting
   }
 
+  // Fabric handles click-to-select natively on pointerdown.
+  // GestureRecognizer must not duplicate this on pointerup.
+  readonly handlesNativeClickSelect = true
+
   // ─── Input Action Handler ─────────────────────────────────────────────────
 
   applyPan(dx: number, dy: number): void {
@@ -1008,6 +1012,30 @@ export class FabricEngine implements LayoutEngine {
       const obj = opt.target
       if (obj) this.interacting = true
       if (!obj) return
+
+      // ActiveSelection: capture pre-drag state for all group children
+      if (obj instanceof fabric.ActiveSelection) {
+        this.lastGoodPos.set('__activeSelection', { left: obj.left ?? 0, top: obj.top ?? 0 })
+        for (const child of obj.getObjects()) {
+          const gid = (child as unknown as Record<string, unknown>)[GROUP_DATA_KEY] as string
+          if (!gid) continue
+          const group = this.groupMap.get(gid)
+          const renderer = this.rendererMap.get(gid)
+          if (group && renderer) {
+            const pos = renderer.readPosition()
+            this.preDragState.set(gid, {
+              left: child.left ?? 0,
+              top: child.top ?? 0,
+              lowerLeftX: pos.x,
+              lowerLeftY: pos.y,
+              width: group.width,
+              height: group.height
+            })
+          }
+        }
+        return
+      }
+
       const groupId = (obj as unknown as Record<string, unknown>)[GROUP_DATA_KEY] as string
       if (groupId) {
         const group = this.groupMap.get(groupId)
@@ -1031,6 +1059,12 @@ export class FabricEngine implements LayoutEngine {
       if (this.disposed) return
       const obj = e.target
       if (!obj) return
+
+      // Multi-select: commit all groups and shapes in the ActiveSelection
+      if (obj instanceof fabric.ActiveSelection) {
+        this.handleActiveSelectionModified(obj)
+        return
+      }
 
       const shapeId = (obj as unknown as Record<string, unknown>)[SHAPE_DATA_KEY] as string
       if (shapeId) {
@@ -1160,6 +1194,94 @@ export class FabricEngine implements LayoutEngine {
       this.lastGoodPos.delete(groupId)
       this.emitter.emit('groupMoved', { id: groupId, x: group.x, y: group.y })
     }
+  }
+
+  /**
+   * Handle object:modified for an ActiveSelection (multi-select drag).
+   * Commits all group positions and shape positions atomically.
+   * Live collision prevention in object:moving should have already blocked
+   * overlapping moves, but we do a safety check and revert if needed.
+   */
+  private handleActiveSelectionModified(sel: fabric.ActiveSelection): void {
+    const children = sel.getObjects()
+
+    // Collect selected group IDs for collision exclusion
+    const selectedGroupIds = new Set<string>()
+    for (const child of children) {
+      const gid = (child as unknown as Record<string, unknown>)[GROUP_DATA_KEY] as string
+      if (gid) selectedGroupIds.add(gid)
+    }
+
+    // Safety collision check — should rarely trigger since object:moving prevents it
+    let hasCollision = false
+    for (const child of children) {
+      const gid = (child as unknown as Record<string, unknown>)[GROUP_DATA_KEY] as string
+      if (!gid) continue
+      const group = this.groupMap.get(gid)
+      const renderer = this.rendererMap.get(gid)
+      if (!group || !renderer) continue
+
+      const pos = renderer.readPosition()
+      const proposed = { x: pos.x, y: pos.y, width: group.width, height: group.height }
+      if (checkGroupCollision(proposed, gid, this.getAllGroups(), selectedGroupIds)) {
+        hasCollision = true
+        break
+      }
+    }
+
+    if (hasCollision) {
+      // Revert the entire selection to pre-drag position
+      const savedSelPos = this.lastGoodPos.get('__activeSelection')
+      if (savedSelPos) {
+        sel.set({ left: savedSelPos.left, top: savedSelPos.top })
+        sel.setCoords()
+        this.canvas?.requestRenderAll()
+      }
+      // Flash collision on all group renderers
+      for (const gid of selectedGroupIds) {
+        const renderer = this.rendererMap.get(gid)
+        if (renderer) this.flashCollision(renderer)
+      }
+      // Clean up
+      for (const gid of selectedGroupIds) {
+        this.preDragState.delete(gid)
+      }
+      this.lastGoodPos.delete('__activeSelection')
+      return
+    }
+
+    // No collision — commit all positions
+    for (const child of children) {
+      const gid = (child as unknown as Record<string, unknown>)[GROUP_DATA_KEY] as string
+      if (gid) {
+        const group = this.groupMap.get(gid)
+        const renderer = this.rendererMap.get(gid)
+        if (group && renderer) {
+          const pos = renderer.readPosition()
+          group.x = pos.x
+          group.y = pos.y
+          this.emitter.emit('groupMoved', { id: gid, x: pos.x, y: pos.y })
+        }
+        this.preDragState.delete(gid)
+        continue
+      }
+
+      const shapeId = (child as unknown as Record<string, unknown>)[SHAPE_DATA_KEY] as string
+      if (shapeId) {
+        // World position for shapes inside ActiveSelection
+        const matrix = child.calcTransformMatrix()
+        const worldX = matrix[4]
+        const worldY = matrix[5]
+        const data = this.shapeMap.get(shapeId)
+        if (data) {
+          data.x = worldX
+          data.y = worldY
+        }
+        this.emitter.emit('shapeMoved', { id: shapeId, x: worldX, y: worldY })
+      }
+    }
+
+    this.lastGoodPos.delete('__activeSelection')
   }
 
   /** Create or update a non-scaling overlay rect showing grid-snapped resize preview. */
@@ -1295,38 +1417,80 @@ export class FabricEngine implements LayoutEngine {
       const gridEnabled = this.gridConfig.enabled
       const size = this.gridConfig.size
 
-      // Multi-select (ActiveSelection): snap based on first group's lower-left corner.
-      // Using the frame center would cause half-grid snapping when the combined
-      // frame width is an odd number of grid units.
+      // Multi-select (ActiveSelection): snap based on first group's lower-left corner,
+      // then collision-check all groups against non-selected groups.
       if (obj instanceof fabric.ActiveSelection) {
-        if (!gridEnabled) return
         const children = obj.getObjects()
-        const firstGroupObj = children.find(
-          (o) => (o as unknown as Record<string, unknown>)[GROUP_DATA_KEY]
-        )
-        if (firstGroupObj) {
-          const gid = (firstGroupObj as unknown as Record<string, unknown>)[
-            GROUP_DATA_KEY
-          ] as string
-          const group = this.groupMap.get(gid)
-          if (group) {
-            // Child left/top is relative to ActiveSelection center.
-            // World centroid = selectionCenter + childOffset
-            const worldCentroidX = (obj.left ?? 0) + (firstGroupObj.left ?? 0)
-            const worldCentroidY = (obj.top ?? 0) + (firstGroupObj.top ?? 0)
-            const lowerLeftX = worldCentroidX - group.width / 2
-            const lowerLeftY = worldCentroidY + group.height / 2
-            const dx = Math.round(lowerLeftX / size) * size - lowerLeftX
-            const dy = Math.round(lowerLeftY / size) * size - lowerLeftY
-            obj.set({ left: (obj.left ?? 0) + dx, top: (obj.top ?? 0) + dy })
+
+        if (gridEnabled) {
+          const firstGroupObj = children.find(
+            (o) => (o as unknown as Record<string, unknown>)[GROUP_DATA_KEY]
+          )
+          if (firstGroupObj) {
+            const gid = (firstGroupObj as unknown as Record<string, unknown>)[
+              GROUP_DATA_KEY
+            ] as string
+            const group = this.groupMap.get(gid)
+            if (group) {
+              // Child left/top is relative to ActiveSelection center.
+              // World centroid = selectionCenter + childOffset
+              const worldCentroidX = (obj.left ?? 0) + (firstGroupObj.left ?? 0)
+              const worldCentroidY = (obj.top ?? 0) + (firstGroupObj.top ?? 0)
+              const lowerLeftX = worldCentroidX - group.width / 2
+              const lowerLeftY = worldCentroidY + group.height / 2
+              const dx = Math.round(lowerLeftX / size) * size - lowerLeftX
+              const dy = Math.round(lowerLeftY / size) * size - lowerLeftY
+              obj.set({ left: (obj.left ?? 0) + dx, top: (obj.top ?? 0) + dy })
+            }
+          } else {
+            // No groups — snap frame center
+            obj.set({
+              left: Math.round((obj.left ?? 0) / size) * size,
+              top: Math.round((obj.top ?? 0) / size) * size
+            })
           }
-        } else {
-          // No groups — snap frame center
-          obj.set({
-            left: Math.round((obj.left ?? 0) / size) * size,
-            top: Math.round((obj.top ?? 0) / size) * size
-          })
         }
+
+        // Live collision prevention for multi-select:
+        // Check each group in the selection against non-selected groups.
+        const selectedGroupIds = new Set<string>()
+        for (const child of children) {
+          const gid = (child as unknown as Record<string, unknown>)[GROUP_DATA_KEY] as string
+          if (gid) selectedGroupIds.add(gid)
+        }
+
+        let hasCollision = false
+        for (const child of children) {
+          const gid = (child as unknown as Record<string, unknown>)[GROUP_DATA_KEY] as string
+          if (!gid) continue
+          const group = this.groupMap.get(gid)
+          if (!group) continue
+
+          // World centroid = selection center + child offset
+          const worldCX = (obj.left ?? 0) + (child.left ?? 0)
+          const worldCY = (obj.top ?? 0) + (child.top ?? 0)
+          const lowerLeftX = worldCX - group.width / 2
+          const lowerLeftY = worldCY + group.height / 2
+
+          const proposed = {
+            x: lowerLeftX,
+            y: lowerLeftY,
+            width: group.width,
+            height: group.height
+          }
+          if (checkGroupCollision(proposed, gid, this.getAllGroups(), selectedGroupIds)) {
+            hasCollision = true
+            break
+          }
+        }
+
+        const lastGood = this.lastGoodPos.get('__activeSelection')
+        if (hasCollision && lastGood) {
+          obj.set({ left: lastGood.left, top: lastGood.top })
+        } else {
+          this.lastGoodPos.set('__activeSelection', { left: obj.left ?? 0, top: obj.top ?? 0 })
+        }
+
         obj.setCoords()
         return
       }

--- a/src/renderer/src/layout-engine/gesture-recognizer.ts
+++ b/src/renderer/src/layout-engine/gesture-recognizer.ts
@@ -223,7 +223,14 @@ export class GestureRecognizer {
 
       case 'dragReady': {
         // Pointer released without exceeding drag threshold → click
-        if (this.startTargetId) {
+        // If the engine handles click-select natively (e.g., Fabric), skip
+        // object clicks to avoid double-processing. Still handle empty-canvas
+        // clicks for deselection.
+        if (this.handler.handlesNativeClickSelect) {
+          if (!this.startTargetId && !this.startShift) {
+            this.handler.clearSelection()
+          }
+        } else if (this.startTargetId) {
           // Click on a shape/group
           if (this.startShift) {
             // Shift-click: toggle selection

--- a/src/renderer/src/layout-engine/input-action-handler.ts
+++ b/src/renderer/src/layout-engine/input-action-handler.ts
@@ -86,4 +86,12 @@ export interface InputActionHandler {
 
   /** Whether the engine is currently handling an interaction (drag, resize, transform). */
   isInteracting(): boolean
+
+  /**
+   * Whether the engine handles click-to-select natively (e.g., Fabric.js
+   * selects on pointerdown). When true, the GestureRecognizer skips its
+   * own click-select handling to avoid double-processing conflicts.
+   * Rubber-band selection is still handled by the GestureRecognizer.
+   */
+  handlesNativeClickSelect?: boolean
 }

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -454,7 +454,8 @@ export class KonvaEngine implements LayoutEngine {
         getAllGroups: () => this.getAllGroups(),
         applySnapDeltaToSiblings: (dx, dy) => this.applySnapDeltaToSiblings(dx, dy),
         getSelectedGroupIds: () => this.getSelectedGroupIds(),
-        revertMultiSelectDrag: () => this.revertMultiSelectDrag()
+        revertMultiSelectDrag: () => this.revertMultiSelectDrag(),
+        isMultiSelectReverted: () => this.multiSelectReverted
       },
       (id, x, y) => {
         const g = this.groupMap.get(id)

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -14,6 +14,7 @@ import type {
 } from './types'
 import { registerEngine } from './create-engine'
 import { KonvaGroupRenderer } from './konva-group-renderer'
+import { checkGroupCollision } from './collision'
 import type { HitResult } from './input-action-handler'
 
 // ─── Constants ──────────────────────────────────────────────────────────────────
@@ -452,10 +453,7 @@ export class KonvaEngine implements LayoutEngine {
         getGridConfig: () => this.gridConfig,
         getTransformer: () => this.transformer,
         getAllGroups: () => this.getAllGroups(),
-        applySnapDeltaToSiblings: (dx, dy) => this.applySnapDeltaToSiblings(dx, dy),
-        getSelectedGroupIds: () => this.getSelectedGroupIds(),
-        revertMultiSelectDrag: () => this.revertMultiSelectDrag(),
-        isMultiSelectReverted: () => this.multiSelectReverted
+        finalizeMultiSelectDrag: () => this.finalizeMultiSelectDrag()
       },
       (id, x, y) => {
         const g = this.groupMap.get(id)
@@ -622,19 +620,16 @@ export class KonvaEngine implements LayoutEngine {
 
   // ─── Multi-Select Drag Support ──────────────────────────────────────────────
 
-  /** Guard: prevents multiple bins from applying the same snap delta to shapes. */
-  private snapDeltaApplied = false
-
   /** Pre-drag positions for all nodes in the selection, keyed by node ID. */
   private preDragPositions = new Map<string, { x: number; y: number }>()
 
-  /** Guard: prevents multiple bins from triggering revert. */
-  private multiSelectReverted = false
+  /** Idempotent guard: ensures only one finalization per drag batch. */
+  private multiDragFinalized = false
 
-  /** Capture pre-drag positions for all selected nodes. Called from setupDragTracking. */
+  /** Capture pre-drag positions for all selected nodes. Called on dragstart. */
   private capturePreDragPositions(): void {
     this.preDragPositions.clear()
-    this.multiSelectReverted = false
+    this.multiDragFinalized = false
     const nodes = this.transformer?.nodes() ?? []
     for (const node of nodes) {
       this.preDragPositions.set(node.id(), { x: node.x(), y: node.y() })
@@ -642,67 +637,121 @@ export class KonvaEngine implements LayoutEngine {
   }
 
   /**
-   * Offset all non-group (shape) nodes in the Transformer selection by the
-   * given delta. Called by KonvaGroupRenderer after a bin snaps to the grid
-   * during multi-select dragend. Idempotent per synchronous batch — the first
-   * call applies, subsequent calls (from other bins) are ignored since all
-   * bins snap by the same delta.
+   * Atomically finalize a multi-select drag: snap, collision-check, then
+   * either commit all data model changes or revert the entire selection.
+   *
+   * Called from each group renderer's dragend — idempotent, only the first
+   * call per drag batch does actual work.
+   *
+   * Sequence:
+   * 1. Snap the first group to grid, compute delta
+   * 2. Apply delta to all other Konva nodes (positions only, no data model)
+   * 3. Check collision for every group against non-selected groups
+   * 4. Collision → revert all nodes to pre-drag positions, flash red
+   * 5. No collision → update data model (groupMap + shapeMap), emit events
    */
-  private applySnapDeltaToSiblings(dx: number, dy: number): void {
-    if (this.snapDeltaApplied) return
-    this.snapDeltaApplied = true
-
-    // Reset the guard on the next microtask (after all synchronous dragend handlers fire)
-    queueMicrotask(() => {
-      this.snapDeltaApplied = false
-    })
+  private finalizeMultiSelectDrag(): void {
+    if (this.multiDragFinalized) return
+    this.multiDragFinalized = true
 
     const nodes = this.transformer?.nodes() ?? []
-    for (const node of nodes) {
-      // Skip groups (bins) — they snap themselves
-      if (node.name() === 'group') continue
-      node.position({ x: node.x() + dx, y: node.y() + dy })
+    if (nodes.length <= 1) return
 
-      // Sync shape data model
-      const id = node.id()
-      const data = this.shapeMap.get(id)
-      if (data) {
-        data.x = node.x()
-        data.y = node.y()
+    const gridConfig = this.gridConfig
+
+    // Collect selected group IDs for collision exclusion
+    const selectedIds = new Set<string>()
+    for (const node of nodes) {
+      if (node.name() === 'group') selectedIds.add(node.id())
+    }
+
+    // Step 1: Snap the first group and compute delta
+    let snapDx = 0
+    let snapDy = 0
+    if (gridConfig.enabled) {
+      for (const node of nodes) {
+        if (node.name() !== 'group') continue
+        const renderer = this.rendererMap.get(node.id())
+        if (!renderer) continue
+        const preSnapX = node.x()
+        const preSnapY = node.y()
+        renderer.snapToGrid(gridConfig.size)
+        snapDx = node.x() - preSnapX
+        snapDy = node.y() - preSnapY
+        break // only use the first group to compute delta
       }
-      this.emitter.emit('shapeMoved', { id, x: node.x(), y: node.y() })
     }
 
-    this.transformer?.forceUpdate()
-    this.mainLayer?.batchDraw()
-  }
+    // Step 2: Apply delta to all OTHER nodes (Konva positions only, no data model)
+    if (snapDx !== 0 || snapDy !== 0) {
+      let firstGroup = true
+      for (const node of nodes) {
+        if (node.name() === 'group' && firstGroup) {
+          firstGroup = false
+          continue // skip the already-snapped group
+        }
+        node.position({ x: node.x() + snapDx, y: node.y() + snapDy })
+      }
+      this.transformer?.forceUpdate()
+      this.mainLayer?.batchDraw()
+    }
 
-  /** Return the IDs of all groups in the current Transformer selection. */
-  private getSelectedGroupIds(): Set<string> {
-    const ids = new Set<string>()
-    const nodes = this.transformer?.nodes() ?? []
+    // Step 3: Check collision for ALL groups in selection
+    let hasCollision = false
     for (const node of nodes) {
-      if (node.name() === 'group') ids.add(node.id())
+      if (node.name() !== 'group') continue
+      const renderer = this.rendererMap.get(node.id())
+      if (!renderer) continue
+      const pos = renderer.readPosition()
+      const group = this.groupMap.get(node.id())
+      if (!group) continue
+
+      const proposed = { x: pos.x, y: pos.y, width: group.width, height: group.height }
+      if (checkGroupCollision(proposed, node.id(), this.getAllGroups(), selectedIds)) {
+        hasCollision = true
+        break
+      }
     }
-    return ids
-  }
 
-  /**
-   * Revert all nodes in the Transformer selection to their pre-drag positions.
-   * Idempotent per synchronous batch — only the first call applies.
-   */
-  private revertMultiSelectDrag(): void {
-    if (this.multiSelectReverted) return
-    this.multiSelectReverted = true
+    // Step 4: Collision → revert all nodes to pre-drag, flash, done
+    if (hasCollision) {
+      for (const node of nodes) {
+        const pre = this.preDragPositions.get(node.id())
+        if (pre) node.position(pre)
+      }
+      this.transformer?.forceUpdate()
+      this.mainLayer?.batchDraw()
 
-    const nodes = this.transformer?.nodes() ?? []
+      // Flash collision on all group renderers in the selection
+      for (const node of nodes) {
+        if (node.name() !== 'group') continue
+        this.rendererMap.get(node.id())?.flashCollision()
+      }
+      return
+    }
+
+    // Step 5: No collision → commit all data model updates, emit events
     for (const node of nodes) {
-      const pre = this.preDragPositions.get(node.id())
-      if (pre) node.position(pre)
+      const id = node.id()
+      if (node.name() === 'group') {
+        const renderer = this.rendererMap.get(id)
+        if (!renderer) continue
+        const pos = renderer.readPosition()
+        const g = this.groupMap.get(id)
+        if (g) {
+          g.x = pos.x
+          g.y = pos.y
+        }
+        this.emitter.emit('groupMoved', { id, x: pos.x, y: pos.y })
+      } else {
+        const data = this.shapeMap.get(id)
+        if (data) {
+          data.x = node.x()
+          data.y = node.y()
+        }
+        this.emitter.emit('shapeMoved', { id, x: node.x(), y: node.y() })
+      }
     }
-
-    this.transformer?.forceUpdate()
-    this.mainLayer?.batchDraw()
   }
 
   // ─── Selection ──────────────────────────────────────────────────────────────

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -452,7 +452,9 @@ export class KonvaEngine implements LayoutEngine {
         getGridConfig: () => this.gridConfig,
         getTransformer: () => this.transformer,
         getAllGroups: () => this.getAllGroups(),
-        applySnapDeltaToSiblings: (dx, dy) => this.applySnapDeltaToSiblings(dx, dy)
+        applySnapDeltaToSiblings: (dx, dy) => this.applySnapDeltaToSiblings(dx, dy),
+        getSelectedGroupIds: () => this.getSelectedGroupIds(),
+        revertMultiSelectDrag: () => this.revertMultiSelectDrag()
       },
       (id, x, y) => {
         const g = this.groupMap.get(id)
@@ -484,6 +486,11 @@ export class KonvaEngine implements LayoutEngine {
       }
     )
     this.rendererMap.set(group.id, renderer)
+
+    // Capture pre-drag positions for all selected nodes when any group starts dragging
+    renderer.konvaGroup.on('dragstart', () => {
+      this.capturePreDragPositions()
+    })
 
     // Move children into group (positions relative to group centroid)
     const centroidX = group.x + group.width / 2
@@ -612,10 +619,26 @@ export class KonvaEngine implements LayoutEngine {
     return Array.from(this.groupMap.keys()).map((id) => this.getGroup(id)!)
   }
 
-  // ─── Multi-Select Snap Compensation ─────────────────────────────────────────
+  // ─── Multi-Select Drag Support ──────────────────────────────────────────────
 
   /** Guard: prevents multiple bins from applying the same snap delta to shapes. */
   private snapDeltaApplied = false
+
+  /** Pre-drag positions for all nodes in the selection, keyed by node ID. */
+  private preDragPositions = new Map<string, { x: number; y: number }>()
+
+  /** Guard: prevents multiple bins from triggering revert. */
+  private multiSelectReverted = false
+
+  /** Capture pre-drag positions for all selected nodes. Called from setupDragTracking. */
+  private capturePreDragPositions(): void {
+    this.preDragPositions.clear()
+    this.multiSelectReverted = false
+    const nodes = this.transformer?.nodes() ?? []
+    for (const node of nodes) {
+      this.preDragPositions.set(node.id(), { x: node.x(), y: node.y() })
+    }
+  }
 
   /**
    * Offset all non-group (shape) nodes in the Transformer selection by the
@@ -647,6 +670,34 @@ export class KonvaEngine implements LayoutEngine {
         data.y = node.y()
       }
       this.emitter.emit('shapeMoved', { id, x: node.x(), y: node.y() })
+    }
+
+    this.transformer?.forceUpdate()
+    this.mainLayer?.batchDraw()
+  }
+
+  /** Return the IDs of all groups in the current Transformer selection. */
+  private getSelectedGroupIds(): Set<string> {
+    const ids = new Set<string>()
+    const nodes = this.transformer?.nodes() ?? []
+    for (const node of nodes) {
+      if (node.name() === 'group') ids.add(node.id())
+    }
+    return ids
+  }
+
+  /**
+   * Revert all nodes in the Transformer selection to their pre-drag positions.
+   * Idempotent per synchronous batch — only the first call applies.
+   */
+  private revertMultiSelectDrag(): void {
+    if (this.multiSelectReverted) return
+    this.multiSelectReverted = true
+
+    const nodes = this.transformer?.nodes() ?? []
+    for (const node of nodes) {
+      const pre = this.preDragPositions.get(node.id())
+      if (pre) node.position(pre)
     }
 
     this.transformer?.forceUpdate()

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -451,7 +451,8 @@ export class KonvaEngine implements LayoutEngine {
         layer: this.mainLayer,
         getGridConfig: () => this.gridConfig,
         getTransformer: () => this.transformer,
-        getAllGroups: () => this.getAllGroups()
+        getAllGroups: () => this.getAllGroups(),
+        applySnapDeltaToSiblings: (dx, dy) => this.applySnapDeltaToSiblings(dx, dy)
       },
       (id, x, y) => {
         const g = this.groupMap.get(id)
@@ -609,6 +610,47 @@ export class KonvaEngine implements LayoutEngine {
 
   getAllGroups(): LayoutGroup[] {
     return Array.from(this.groupMap.keys()).map((id) => this.getGroup(id)!)
+  }
+
+  // ─── Multi-Select Snap Compensation ─────────────────────────────────────────
+
+  /** Guard: prevents multiple bins from applying the same snap delta to shapes. */
+  private snapDeltaApplied = false
+
+  /**
+   * Offset all non-group (shape) nodes in the Transformer selection by the
+   * given delta. Called by KonvaGroupRenderer after a bin snaps to the grid
+   * during multi-select dragend. Idempotent per synchronous batch — the first
+   * call applies, subsequent calls (from other bins) are ignored since all
+   * bins snap by the same delta.
+   */
+  private applySnapDeltaToSiblings(dx: number, dy: number): void {
+    if (this.snapDeltaApplied) return
+    this.snapDeltaApplied = true
+
+    // Reset the guard on the next microtask (after all synchronous dragend handlers fire)
+    queueMicrotask(() => {
+      this.snapDeltaApplied = false
+    })
+
+    const nodes = this.transformer?.nodes() ?? []
+    for (const node of nodes) {
+      // Skip groups (bins) — they snap themselves
+      if (node.name() === 'group') continue
+      node.position({ x: node.x() + dx, y: node.y() + dy })
+
+      // Sync shape data model
+      const id = node.id()
+      const data = this.shapeMap.get(id)
+      if (data) {
+        data.x = node.x()
+        data.y = node.y()
+      }
+      this.emitter.emit('shapeMoved', { id, x: node.x(), y: node.y() })
+    }
+
+    this.transformer?.forceUpdate()
+    this.mainLayer?.batchDraw()
   }
 
   // ─── Selection ──────────────────────────────────────────────────────────────

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -661,8 +661,8 @@ export class KonvaEngine implements LayoutEngine {
    * call per drag batch does actual work.
    *
    * Sequence:
-   * 1. Snap the first group to grid, compute delta
-   * 2. Apply delta to all other Konva nodes (positions only, no data model)
+   * 1. Snap the first group to grid, compute the snap delta
+   * 2. Apply that delta to all other selected groups (positions only, no data model)
    * 3. Check collision for every group against non-selected groups
    * 4. Collision → revert all nodes to pre-drag positions, flash red
    * 5. No collision → update data model (groupMap + shapeMap), emit events
@@ -699,11 +699,13 @@ export class KonvaEngine implements LayoutEngine {
       }
     }
 
-    // Step 2: Apply delta to all OTHER nodes (Konva positions only, no data model)
+    // Step 2: Apply snap delta to all OTHER selected groups (Konva positions only, no data model).
+    // Skip shapes — they are children of group Konva nodes and move with their parent.
     if (snapDx !== 0 || snapDy !== 0) {
       let firstGroup = true
       for (const node of nodes) {
-        if (node.name() === 'group' && firstGroup) {
+        if (node.name() !== 'group') continue // skip shapes (they move with parent)
+        if (firstGroup) {
           firstGroup = false
           continue // skip the already-snapped group
         }
@@ -739,10 +741,11 @@ export class KonvaEngine implements LayoutEngine {
       this.transformer?.forceUpdate()
       this.mainLayer?.batchDraw()
 
-      // Flash collision on all group renderers in the selection
+      // Flash collision on all group renderers and emit events
       for (const node of nodes) {
         if (node.name() !== 'group') continue
         this.rendererMap.get(node.id())?.flashCollision()
+        this.emitter.emit('collisionRejected', { id: node.id(), reason: 'move' })
       }
       return
     }

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -626,8 +626,25 @@ export class KonvaEngine implements LayoutEngine {
   /** Idempotent guard: ensures only one finalization per drag batch. */
   private multiDragFinalized = false
 
-  /** Capture pre-drag positions for all selected nodes. Called on dragstart. */
+  /** Guard: ensures only the first dragstart per batch captures positions. */
+  private preDragCaptured = false
+
+  /**
+   * Capture pre-drag positions for all selected nodes. Called on dragstart.
+   *
+   * Each node in the Transformer fires its own dragstart. If we recaptured
+   * on every one, later dragstart events could read positions that the
+   * Transformer already started moving — causing cumulative drift on revert.
+   * The guard ensures only the first dragstart captures; the microtask
+   * resets the guard after the synchronous dragstart batch completes.
+   */
   private capturePreDragPositions(): void {
+    if (this.preDragCaptured) return
+    this.preDragCaptured = true
+    queueMicrotask(() => {
+      this.preDragCaptured = false
+    })
+
     this.preDragPositions.clear()
     this.multiDragFinalized = false
     const nodes = this.transformer?.nodes() ?? []

--- a/src/renderer/src/layout-engine/konva-group-renderer.ts
+++ b/src/renderer/src/layout-engine/konva-group-renderer.ts
@@ -278,15 +278,24 @@ export class KonvaGroupRenderer implements GroupRenderer {
       }
 
       const pos = this.readPosition()
-      const proposed = { x: pos.x, y: pos.y, width: this.width, height: this.height }
-      const collider = checkGroupCollision(proposed, this.groupId, this.deps.getAllGroups())
-      if (collider && this.lastGoodPos) {
-        this.konvaGroup.position(this.lastGoodPos)
-        this.deps.getTransformer()?.forceUpdate()
-        this.flashCollision()
-        this.onCollisionRejected?.(this.groupId, 'move')
-        this.lastGoodPos = null
-        return
+
+      // Skip collision detection during multi-select: getAllGroups() reads
+      // from the data model which still has pre-drag positions for sibling
+      // bins. Adjacent bins that moved together would false-positive as
+      // overlapping. Since all bins move by the same delta and snap by the
+      // same delta, relative positions are preserved and collisions can't
+      // be introduced by a uniform translation.
+      if (!isMultiSelect) {
+        const proposed = { x: pos.x, y: pos.y, width: this.width, height: this.height }
+        const collider = checkGroupCollision(proposed, this.groupId, this.deps.getAllGroups())
+        if (collider && this.lastGoodPos) {
+          this.konvaGroup.position(this.lastGoodPos)
+          this.deps.getTransformer()?.forceUpdate()
+          this.flashCollision()
+          this.onCollisionRejected?.(this.groupId, 'move')
+          this.lastGoodPos = null
+          return
+        }
       }
 
       this.lastGoodPos = null

--- a/src/renderer/src/layout-engine/konva-group-renderer.ts
+++ b/src/renderer/src/layout-engine/konva-group-renderer.ts
@@ -13,6 +13,13 @@ export interface KonvaGroupRendererDeps {
   getGridConfig(): GridConfig
   getTransformer(): Konva.Transformer | null
   getAllGroups(): LayoutGroup[]
+  /**
+   * After a bin snaps to the grid during multi-select dragend, offset all
+   * non-group sibling nodes in the Transformer selection by the same delta
+   * so shapes follow bins. Idempotent within a synchronous batch — only
+   * the first call per batch applies; subsequent calls are ignored.
+   */
+  applySnapDeltaToSiblings(dx: number, dy: number): void
 }
 
 /**
@@ -248,10 +255,26 @@ export class KonvaGroupRenderer implements GroupRenderer {
 
     // On drag end: final snap + sync data model. Safety collision check
     // for edge cases (multi-select, etc.) — flash red only if truly overlapping.
+    // In multi-select, also offset sibling shapes by the snap delta so they
+    // follow the bins.
     this.konvaGroup.on('dragend', () => {
       const gridConfig = this.deps.getGridConfig()
+      const selectedNodes = this.deps.getTransformer()?.nodes() ?? []
+      const isMultiSelect = selectedNodes.length > 1
+
       if (gridConfig.enabled) {
+        const preSnapX = this.konvaGroup.x()
+        const preSnapY = this.konvaGroup.y()
         this.snapToGrid(gridConfig.size)
+
+        // In multi-select, offset sibling shapes by the snap delta
+        if (isMultiSelect) {
+          const dx = this.konvaGroup.x() - preSnapX
+          const dy = this.konvaGroup.y() - preSnapY
+          if (dx !== 0 || dy !== 0) {
+            this.deps.applySnapDeltaToSiblings(dx, dy)
+          }
+        }
       }
 
       const pos = this.readPosition()

--- a/src/renderer/src/layout-engine/konva-group-renderer.ts
+++ b/src/renderer/src/layout-engine/konva-group-renderer.ts
@@ -14,18 +14,11 @@ export interface KonvaGroupRendererDeps {
   getTransformer(): Konva.Transformer | null
   getAllGroups(): LayoutGroup[]
   /**
-   * After a bin snaps to the grid during multi-select dragend, offset all
-   * non-group sibling nodes in the Transformer selection by the same delta
-   * so shapes follow bins. Idempotent within a synchronous batch — only
-   * the first call per batch applies; subsequent calls are ignored.
+   * Atomically finalize a multi-select drag: snap all bins, collision-check,
+   * then either commit all data model changes or revert the entire selection.
+   * Idempotent — only the first call per drag batch does work.
    */
-  applySnapDeltaToSiblings(dx: number, dy: number): void
-  /** Return the IDs of all groups currently in the Transformer selection. */
-  getSelectedGroupIds(): Set<string>
-  /** Revert all nodes in the Transformer selection to their pre-drag positions. */
-  revertMultiSelectDrag(): void
-  /** Whether the current multi-select drag has already been reverted. */
-  isMultiSelectReverted(): boolean
+  finalizeMultiSelectDrag(): void
 }
 
 /**
@@ -53,6 +46,12 @@ export class KonvaGroupRenderer implements GroupRenderer {
 
   /** Last known non-colliding centroid during drag, for live collision prevention. */
   private lastGoodPos: { x: number; y: number } | null = null
+  /** Timeout handle for collision flash — cleared before starting a new flash. */
+  private flashTimeout: ReturnType<typeof setTimeout> | null = null
+  /** Original stroke color from the group style, for reliable flash restore. */
+  private origStroke: string
+  /** Original stroke width from the group style, for reliable flash restore. */
+  private origStrokeWidth: number
   /** Snapshot of bounds before a resize starts, for edge-anchoring. */
   private preResizeBounds: { x: number; y: number; width: number; height: number } | null = null
   /** Non-scaling overlay rect shown during resize as ghost preview. */
@@ -72,6 +71,8 @@ export class KonvaGroupRenderer implements GroupRenderer {
     this.groupId = group.id
     this.width = group.width
     this.height = group.height
+    this.origStroke = group.style.stroke
+    this.origStrokeWidth = group.style.strokeWidth
 
     // Lower-left → centroid
     const centroidX = group.x + group.width / 2
@@ -140,6 +141,9 @@ export class KonvaGroupRenderer implements GroupRenderer {
             strokeWidth: current.style.strokeWidth,
             cornerRadius: current.style.cornerRadius ?? 0
           })
+          // Keep flash-restore values in sync with the configured style
+          this.origStroke = current.style.stroke
+          this.origStrokeWidth = current.style.strokeWidth
         }
       }
     }
@@ -259,71 +263,38 @@ export class KonvaGroupRenderer implements GroupRenderer {
       }
     })
 
-    // On drag end: final snap + sync data model. Safety collision check
-    // for edge cases (multi-select, etc.) — flash red only if truly overlapping.
-    // In multi-select, also offset sibling shapes by the snap delta so they
-    // follow the bins.
+    // On drag end: final snap + sync data model.
+    // Multi-select: delegate to the engine's atomic finalizeMultiSelectDrag().
+    // Single-select: snap, collision-check, commit or revert locally.
     this.konvaGroup.on('dragend', () => {
       const selectedNodes = this.deps.getTransformer()?.nodes() ?? []
       const isMultiSelect = selectedNodes.length > 1
 
-      // If another bin already triggered a multi-select revert, skip entirely —
-      // our position has been restored and any further snap/collision work
-      // would introduce floating-point drift from centroid conversions.
-      if (isMultiSelect && this.deps.isMultiSelectReverted()) {
+      if (isMultiSelect) {
+        // Engine handles snap, collision, commit/revert atomically for all
+        // nodes in the selection. Idempotent — only the first bin's dragend
+        // triggers actual work; subsequent calls are no-ops.
+        this.deps.finalizeMultiSelectDrag()
         this.lastGoodPos = null
         return
       }
 
+      // Single-bin: snap + collision check
       const gridConfig = this.deps.getGridConfig()
-
       if (gridConfig.enabled) {
-        const preSnapX = this.konvaGroup.x()
-        const preSnapY = this.konvaGroup.y()
         this.snapToGrid(gridConfig.size)
-
-        // In multi-select, offset sibling shapes by the snap delta
-        if (isMultiSelect) {
-          const dx = this.konvaGroup.x() - preSnapX
-          const dy = this.konvaGroup.y() - preSnapY
-          if (dx !== 0 || dy !== 0) {
-            this.deps.applySnapDeltaToSiblings(dx, dy)
-          }
-        }
       }
 
       const pos = this.readPosition()
       const proposed = { x: pos.x, y: pos.y, width: this.width, height: this.height }
-
-      if (isMultiSelect) {
-        // Multi-select: check collision against non-selected groups only
-        // (selected siblings have stale data model positions). If any bin
-        // in the selection collides with a stationary group, revert the
-        // entire selection.
-        const selectedIds = this.deps.getSelectedGroupIds()
-        const collider = checkGroupCollision(
-          proposed,
-          this.groupId,
-          this.deps.getAllGroups(),
-          selectedIds
-        )
-        if (collider) {
-          this.deps.revertMultiSelectDrag()
-          this.flashCollision()
-          this.lastGoodPos = null
-          return
-        }
-      } else {
-        // Single-bin: check against all other groups
-        const collider = checkGroupCollision(proposed, this.groupId, this.deps.getAllGroups())
-        if (collider && this.lastGoodPos) {
-          this.konvaGroup.position(this.lastGoodPos)
-          this.deps.getTransformer()?.forceUpdate()
-          this.flashCollision()
-          this.onCollisionRejected?.(this.groupId, 'move')
-          this.lastGoodPos = null
-          return
-        }
+      const collider = checkGroupCollision(proposed, this.groupId, this.deps.getAllGroups())
+      if (collider && this.lastGoodPos) {
+        this.konvaGroup.position(this.lastGoodPos)
+        this.deps.getTransformer()?.forceUpdate()
+        this.flashCollision()
+        this.onCollisionRejected?.(this.groupId, 'move')
+        this.lastGoodPos = null
+        return
       }
 
       this.lastGoodPos = null
@@ -490,18 +461,29 @@ export class KonvaGroupRenderer implements GroupRenderer {
     this.deps.layer.batchDraw()
   }
 
-  /** Brief red flash on the group border to indicate a collision rejection. */
-  private flashCollision(): void {
+  /**
+   * Brief red flash on the group border to indicate a collision rejection.
+   * Cancels any pending flash timeout before starting a new one, and restores
+   * the stroke from the configured group style (not from current visual state,
+   * which may already be red from a previous flash).
+   */
+  flashCollision(): void {
     const bgRect = this.konvaGroup.findOne('.__groupBg') as Konva.Rect | undefined
     if (!bgRect) return
-    const origStroke = bgRect.stroke()
-    const origStrokeWidth = bgRect.strokeWidth()
+
+    // Cancel any pending restore so flashes don't stack
+    if (this.flashTimeout !== null) {
+      clearTimeout(this.flashTimeout)
+      this.flashTimeout = null
+    }
+
     bgRect.stroke('#ef4444')
     bgRect.strokeWidth(2)
     this.deps.layer.batchDraw()
-    setTimeout(() => {
-      bgRect.stroke(origStroke ?? '#666666')
-      bgRect.strokeWidth(origStrokeWidth ?? 1)
+    this.flashTimeout = setTimeout(() => {
+      this.flashTimeout = null
+      bgRect.stroke(this.origStroke)
+      bgRect.strokeWidth(this.origStrokeWidth)
       this.deps.layer.batchDraw()
     }, 300)
   }

--- a/src/renderer/src/layout-engine/konva-group-renderer.ts
+++ b/src/renderer/src/layout-engine/konva-group-renderer.ts
@@ -20,6 +20,10 @@ export interface KonvaGroupRendererDeps {
    * the first call per batch applies; subsequent calls are ignored.
    */
   applySnapDeltaToSiblings(dx: number, dy: number): void
+  /** Return the IDs of all groups currently in the Transformer selection. */
+  getSelectedGroupIds(): Set<string>
+  /** Revert all nodes in the Transformer selection to their pre-drag positions. */
+  revertMultiSelectDrag(): void
 }
 
 /**
@@ -278,15 +282,28 @@ export class KonvaGroupRenderer implements GroupRenderer {
       }
 
       const pos = this.readPosition()
+      const proposed = { x: pos.x, y: pos.y, width: this.width, height: this.height }
 
-      // Skip collision detection during multi-select: getAllGroups() reads
-      // from the data model which still has pre-drag positions for sibling
-      // bins. Adjacent bins that moved together would false-positive as
-      // overlapping. Since all bins move by the same delta and snap by the
-      // same delta, relative positions are preserved and collisions can't
-      // be introduced by a uniform translation.
-      if (!isMultiSelect) {
-        const proposed = { x: pos.x, y: pos.y, width: this.width, height: this.height }
+      if (isMultiSelect) {
+        // Multi-select: check collision against non-selected groups only
+        // (selected siblings have stale data model positions). If any bin
+        // in the selection collides with a stationary group, revert the
+        // entire selection.
+        const selectedIds = this.deps.getSelectedGroupIds()
+        const collider = checkGroupCollision(
+          proposed,
+          this.groupId,
+          this.deps.getAllGroups(),
+          selectedIds
+        )
+        if (collider) {
+          this.deps.revertMultiSelectDrag()
+          this.flashCollision()
+          this.lastGoodPos = null
+          return
+        }
+      } else {
+        // Single-bin: check against all other groups
         const collider = checkGroupCollision(proposed, this.groupId, this.deps.getAllGroups())
         if (collider && this.lastGoodPos) {
           this.konvaGroup.position(this.lastGoodPos)

--- a/src/renderer/src/layout-engine/konva-group-renderer.ts
+++ b/src/renderer/src/layout-engine/konva-group-renderer.ts
@@ -24,6 +24,8 @@ export interface KonvaGroupRendererDeps {
   getSelectedGroupIds(): Set<string>
   /** Revert all nodes in the Transformer selection to their pre-drag positions. */
   revertMultiSelectDrag(): void
+  /** Whether the current multi-select drag has already been reverted. */
+  isMultiSelectReverted(): boolean
 }
 
 /**
@@ -262,9 +264,18 @@ export class KonvaGroupRenderer implements GroupRenderer {
     // In multi-select, also offset sibling shapes by the snap delta so they
     // follow the bins.
     this.konvaGroup.on('dragend', () => {
-      const gridConfig = this.deps.getGridConfig()
       const selectedNodes = this.deps.getTransformer()?.nodes() ?? []
       const isMultiSelect = selectedNodes.length > 1
+
+      // If another bin already triggered a multi-select revert, skip entirely —
+      // our position has been restored and any further snap/collision work
+      // would introduce floating-point drift from centroid conversions.
+      if (isMultiSelect && this.deps.isMultiSelectReverted()) {
+        this.lastGoodPos = null
+        return
+      }
+
+      const gridConfig = this.deps.getGridConfig()
 
       if (gridConfig.enabled) {
         const preSnapX = this.konvaGroup.x()


### PR DESCRIPTION
## Summary
- When dragging a mixed selection (bins + shapes) in Konva, bins snap to grid on release but shapes stayed put, breaking spatial relationships
- After a bin snaps, compute the snap delta and offset all non-group sibling nodes in the Transformer selection by the same amount
- `queueMicrotask`-based guard ensures the delta is applied only once per synchronous `dragend` batch (all bins snap by the same delta since they were all on-grid pre-drag)

Closes #258

## Test plan
- [ ] In Konva engine, select 2+ bins and a shape together
- [ ] Drag the selection and release — shapes should follow the bins' snap adjustment
- [ ] Verify single-bin drag still snaps correctly
- [ ] Verify collision detection still works during multi-drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)