### PR TITLE
fix(core): preserve child shape positions when bin is resized

### DIFF
--- a/src/renderer/src/layout-engine/fabric-engine.ts
+++ b/src/renderer/src/layout-engine/fabric-engine.ts
@@ -1233,6 +1233,27 @@ export class FabricEngine implements LayoutEngine {
         meta.depthUnits = Math.round(newH / gs)
       }
 
+      // Translate user-shape children so their world positions stay constant.
+      // The bin's centroid moves when the lower-left is preserved across a
+      // resize, so each child's local position (relative to centroid) needs
+      // to shift by the centroid delta to keep the child visually anchored.
+      const preCentroidX = saved.lowerLeftX + saved.width / 2
+      const preCentroidY = saved.lowerLeftY - saved.height / 2
+      const postCentroidX = finalX + newW / 2
+      const postCentroidY = finalY - newH / 2
+      const dx = preCentroidX - postCentroidX
+      const dy = preCentroidY - postCentroidY
+      const internalObjects = (
+        renderer.fabricGroup as unknown as { _objects: fabric.FabricObject[] }
+      )._objects
+      for (const child of internalObjects) {
+        const rec = child as unknown as Record<string, unknown>
+        if (rec[SHAPE_DATA_KEY]) {
+          child.set({ left: (child.left ?? 0) + dx, top: (child.top ?? 0) + dy })
+          child.setCoords()
+        }
+      }
+
       renderer.update({ x: finalX, y: finalY, width: newW, height: newH }, group)
       this.preDragState.delete(groupId)
       this.lastGoodPos.delete(groupId)

--- a/src/renderer/src/layout-engine/fabric-group-renderer.ts
+++ b/src/renderer/src/layout-engine/fabric-group-renderer.ts
@@ -282,23 +282,27 @@ export class FabricGroupRenderer implements GroupRenderer {
 
   /**
    * triggerLayout() recalculates group bounds from children via FitContentLayout.
-   * Decorations must be temporarily removed so they don't inflate bounds.
+   * Decorations and user-shape children must be temporarily removed so they
+   * don't inflate bounds (decorations) or get their left/top rewritten to fit
+   * the new bbox (user shapes — which would corrupt their position relative
+   * to the bin centroid).
    */
   private triggerLayoutSafe(): void {
     const internalObjects = this.getInternalObjects()
-    const decorations: fabric.FabricObject[] = []
+    const removed: fabric.FabricObject[] = []
 
     for (let i = internalObjects.length - 1; i >= 0; i--) {
-      if ((internalObjects[i] as unknown as Record<string, unknown>).__binArtwork) {
-        decorations.push(internalObjects[i])
+      const o = internalObjects[i] as unknown as Record<string, unknown>
+      if (o.__binArtwork || o.__layoutShapeId) {
+        removed.unshift(internalObjects[i])
         internalObjects.splice(i, 1)
       }
     }
 
     this.fabricGroup.triggerLayout()
 
-    for (const dec of decorations) {
-      internalObjects.push(dec)
+    for (const obj of removed) {
+      internalObjects.push(obj)
     }
   }
 }

--- a/src/renderer/src/layout-engine/fabric-group-renderer.ts
+++ b/src/renderer/src/layout-engine/fabric-group-renderer.ts
@@ -294,10 +294,11 @@ export class FabricGroupRenderer implements GroupRenderer {
     for (let i = internalObjects.length - 1; i >= 0; i--) {
       const o = internalObjects[i] as unknown as Record<string, unknown>
       if (o.__binArtwork || o.__layoutShapeId) {
-        removed.unshift(internalObjects[i])
+        removed.push(internalObjects[i])
         internalObjects.splice(i, 1)
       }
     }
+    removed.reverse()
 
     this.fabricGroup.triggerLayout()
 

--- a/src/renderer/src/layout-engine/konva-group-renderer.ts
+++ b/src/renderer/src/layout-engine/konva-group-renderer.ts
@@ -372,6 +372,24 @@ export class KonvaGroupRenderer implements GroupRenderer {
         bgRect.setAttrs({ x: -newW / 2, y: -newH / 2, width: newW, height: newH })
       }
 
+      // Translate user-shape children so their world positions stay constant.
+      // Lower-left is preserved across the resize, so the bin's centroid
+      // shifts; each child's local position (relative to centroid) needs to
+      // shift by the centroid delta to keep the child visually anchored.
+      const preCentroidX = orig.x + orig.width / 2
+      const preCentroidY = orig.y - orig.height / 2
+      const postCentroidX = finalX + newW / 2
+      const postCentroidY = finalY - newH / 2
+      const dx = preCentroidX - postCentroidX
+      const dy = preCentroidY - postCentroidY
+      if (dx !== 0 || dy !== 0) {
+        for (const child of this.konvaGroup.getChildren()) {
+          const name = child.name()
+          if (name === '__groupBg' || name === '__binArtwork') continue
+          child.position({ x: child.x() + dx, y: child.y() + dy })
+        }
+      }
+
       // Reposition centroid from the final lower-left
       this.konvaGroup.position({ x: finalX + newW / 2, y: finalY - newH / 2 })
 

--- a/src/renderer/src/layout-engine/konva-group-renderer.ts
+++ b/src/renderer/src/layout-engine/konva-group-renderer.ts
@@ -384,8 +384,7 @@ export class KonvaGroupRenderer implements GroupRenderer {
       const dy = preCentroidY - postCentroidY
       if (dx !== 0 || dy !== 0) {
         for (const child of this.konvaGroup.getChildren()) {
-          const name = child.name()
-          if (name === '__groupBg' || name === '__binArtwork') continue
+          if (child.hasName('__groupBg') || child.hasName('__binArtwork')) continue
           child.position({ x: child.x() + dx, y: child.y() + dy })
         }
       }


### PR DESCRIPTION
## Summary

- Resizing a bin that contained a child shape produced visible layout corruption (multiple overlapping bin outlines, child sticking past the inner border, decoration grid extending beyond the resized boundary)
- Fixed in both Fabric and Konva engines

## Root cause

Two issues, both surfacing because a bin's lower-left is preserved across a resize so its centroid moves:

1. **Children's local positions weren't updated.** A child at local `(lx, ly)` relative to the OLD centroid drifts in world space by exactly the centroid delta when the centroid shifts. Both engines now translate user-shape children by `(preCentroid − postCentroid)` on resize commit.

2. **Fabric's `triggerLayoutSafe()` only excluded decorations.** User shapes were left in, and `triggerLayout()` would rewrite their `left/top` to fit the new bbox — corrupting positions we just set. Now removes both decorations and user shapes around `triggerLayout`.

## Test plan

Verified programmatically on both engines:

- 3×3 bin with a shape at world (60, −60)
- Resize to 5×4 by dragging BR corner
- Child's screen-space absolute position unchanged
- Single bin outline, decorations fill correctly

- [ ] Manual repro of the bug as reported (multiple overlapping outlines)
- [ ] Manual verification post-fix on Fabric
- [ ] Manual verification post-fix on Konva
- [ ] Resize down (shrink) — child shouldn't jump
- [ ] Resize via TL/TR/BL corners (different anchor edges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)