### PR TITLE
fix(core): bypass enterGroup in Fabric addShape for grouped snapshots

### DIFF
--- a/src/renderer/src/components/DrawingToolLayer.tsx
+++ b/src/renderer/src/components/DrawingToolLayer.tsx
@@ -205,6 +205,10 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
       const id = crypto.randomUUID()
       const name = nextShapeName(engine, 'polygon')
 
+      // Create ungrouped at world coords, then reparent via addToGroup which
+      // handles world→local conversion. Passing groupId directly to addShape
+      // would treat x/y as already group-local and place the shape at the
+      // wrong position.
       engine.addShape({
         id,
         type: 'polygon',
@@ -212,9 +216,10 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
         y: cy,
         points: relativePoints,
         ...baseShapeProps(),
-        groupId: bin?.id ?? null,
+        groupId: null,
         metadata: { ...pocketMetadata(bin, unitHeight), name }
       })
+      if (bin) engine.addToGroup(id, bin.id)
       engine.select([id])
       setState(INITIAL_STATE)
       setActiveTool('select')
@@ -409,9 +414,10 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             width: w,
             height: h,
             ...baseShapeProps(),
-            groupId: bin?.id ?? null,
+            groupId: null,
             metadata: { ...pocketMetadata(bin, unitHeight), name }
           })
+          if (bin) engine.addToGroup(id, bin.id)
           engine.select([id])
           setActiveTool('select')
         }
@@ -431,9 +437,10 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             radiusX: radius,
             radiusY: radius,
             ...baseShapeProps(),
-            groupId: bin?.id ?? null,
+            groupId: null,
             metadata: { ...pocketMetadata(bin, unitHeight), name }
           })
+          if (bin) engine.addToGroup(id, bin.id)
           engine.select([id])
           setActiveTool('select')
         }

--- a/src/renderer/src/layout-engine/fabric-engine.ts
+++ b/src/renderer/src/layout-engine/fabric-engine.ts
@@ -277,7 +277,22 @@ export class FabricEngine implements LayoutEngine {
     this.fabricMap.set(shape.id, obj)
 
     if (shape.groupId && this.rendererMap.has(shape.groupId)) {
-      this.rendererMap.get(shape.groupId)!.fabricGroup.add(obj)
+      // Bypass fabric.Group.add() for the same reason createGroup and addToGroup
+      // do: it calls enterGroup which converts obj.left/top from world space to
+      // group-local. Snapshot-stored shape.x/y for grouped shapes is *already*
+      // group-local, so going through enterGroup double-converts and shifts the
+      // shape by exactly the group centroid on every snapshot round-trip
+      // (engine toggle, save/load). It also kicks FitContentLayout which
+      // distorts the bin's fixed bbox.
+      const renderer = this.rendererMap.get(shape.groupId)!
+      const internalObjects = (
+        renderer.fabricGroup as unknown as { _objects: fabric.FabricObject[] }
+      )._objects
+      obj._set('parent', renderer.fabricGroup)
+      obj._set('group', renderer.fabricGroup)
+      if (this.canvas) obj._set('canvas', this.canvas)
+      internalObjects.push(obj)
+      renderer.fabricGroup.set('dirty', true)
     } else {
       this.canvas?.add(obj)
     }

--- a/src/renderer/src/layout-engine/fabric-engine.ts
+++ b/src/renderer/src/layout-engine/fabric-engine.ts
@@ -277,22 +277,10 @@ export class FabricEngine implements LayoutEngine {
     this.fabricMap.set(shape.id, obj)
 
     if (shape.groupId && this.rendererMap.has(shape.groupId)) {
-      // Bypass fabric.Group.add() for the same reason createGroup and addToGroup
-      // do: it calls enterGroup which converts obj.left/top from world space to
-      // group-local. Snapshot-stored shape.x/y for grouped shapes is *already*
-      // group-local, so going through enterGroup double-converts and shifts the
-      // shape by exactly the group centroid on every snapshot round-trip
-      // (engine toggle, save/load). It also kicks FitContentLayout which
-      // distorts the bin's fixed bbox.
-      const renderer = this.rendererMap.get(shape.groupId)!
-      const internalObjects = (
-        renderer.fabricGroup as unknown as { _objects: fabric.FabricObject[] }
-      )._objects
-      obj._set('parent', renderer.fabricGroup)
-      obj._set('group', renderer.fabricGroup)
-      if (this.canvas) obj._set('canvas', this.canvas)
-      internalObjects.push(obj)
-      renderer.fabricGroup.set('dirty', true)
+      // shape.x/y is already group-local (snapshot semantics). attachChild
+      // bypasses fabric.Group.add() so we don't double-convert via
+      // enterGroup or kick FitContentLayout into corrupting the bin bbox.
+      this.rendererMap.get(shape.groupId)!.attachChild(obj)
     } else {
       this.canvas?.add(obj)
     }
@@ -391,21 +379,15 @@ export class FabricEngine implements LayoutEngine {
     // Move children into group — bypass group.add()/enterGroup to avoid
     // FitContentLayout corrupting the bin's fixed dimensions.
     // Shape coords from the snapshot are already in group-local space.
-    const internalObjects = (renderer.fabricGroup as unknown as { _objects: fabric.FabricObject[] })
-      ._objects
     for (const childId of group.childIds) {
       const obj = this.fabricMap.get(childId)
       if (obj) {
         this.canvas.remove(obj)
-        obj._set('parent', renderer.fabricGroup)
-        obj._set('group', renderer.fabricGroup)
-        obj._set('canvas', this.canvas)
-        internalObjects.push(obj)
+        renderer.attachChild(obj)
       }
       const shape = this.shapeMap.get(childId)
       if (shape) shape.groupId = group.id
     }
-    renderer.fabricGroup.set('dirty', true)
 
     this.canvas.add(renderer.fabricGroup)
     this.canvas.requestRenderAll()
@@ -483,18 +465,7 @@ export class FabricEngine implements LayoutEngine {
       obj.set({ left: localPt.x, top: localPt.y })
       obj.setCoords()
 
-      // Bypass group.add() which calls enterGroup + FitContentLayout, corrupting
-      // the bin's fixed dimensions. Instead push directly onto _objects like
-      // decorations do (see FabricGroupRenderer.setDecorations).
-      const internalObjects = (
-        renderer.fabricGroup as unknown as { _objects: fabric.FabricObject[] }
-      )._objects
-      obj._set('parent', renderer.fabricGroup)
-      obj._set('group', renderer.fabricGroup)
-      obj._set('canvas', this.canvas)
-      internalObjects.push(obj)
-
-      renderer.fabricGroup.set('dirty', true)
+      renderer.attachChild(obj)
 
       group.childIds = [...group.childIds, shapeId]
       shape.groupId = groupId

--- a/src/renderer/src/layout-engine/fabric-group-renderer.ts
+++ b/src/renderer/src/layout-engine/fabric-group-renderer.ts
@@ -251,6 +251,24 @@ export class FabricGroupRenderer implements GroupRenderer {
     this.canvas.remove(this.fabricGroup)
   }
 
+  /**
+   * Insert a Fabric object into this group's `_objects` array directly,
+   * bypassing `fabric.Group.add()`. Used by all paths that move shapes
+   * into a bin (createGroup, addToGroup, addShape) — `group.add()` calls
+   * `enterGroup` (world→local conversion) and `FitContentLayout` (bbox
+   * recompute), both of which corrupt our fixed-dimension bins or
+   * double-convert snapshot-loaded coords. The caller is responsible for
+   * setting `obj.left/top` to the correct group-local position before
+   * calling this.
+   */
+  attachChild(obj: fabric.FabricObject): void {
+    obj._set('parent', this.fabricGroup)
+    obj._set('group', this.fabricGroup)
+    obj._set('canvas', this.canvas)
+    this.getInternalObjects().push(obj)
+    this.fabricGroup.set('dirty', true)
+  }
+
   // ─── Private ──────────────────────────────────────────────────────────────────
 
   private getInternalObjects(): fabric.FabricObject[] {


### PR DESCRIPTION
## Summary

Toggling between Fabric and Konva (or saving and reloading) caused grouped shapes and their containing bins to drift with each round-trip. The drift was exactly the bin's centroid magnitude per round-trip, accumulating linearly.

## Root cause

\`FabricEngine.addShape\` was the last code path still using \`fabric.Group.add(obj)\` to insert a grouped shape. That call applies \`enterGroup\`, which converts the object's \`left/top\` from world to group-local — but \`shape.x/y\` in the snapshot is **already** in group-local space, so \`enterGroup\` double-converts and shifts the shape by the centroid. It also kicks \`FitContentLayout\` which distorts the bin's fixed bbox.

Same pattern \`createGroup\` (#588d97c) and \`addToGroup\` (#ee900ca) already use the \`_objects\`-bypass for. \`addShape\` was the last holdout.

## Reproduction (pre-fix)

Bin at \`(0, 0)\`, 126×126. Shape inside at world \`(60, -60)\`, local \`(-3, 3)\`.

| After | bin lower-left | shape (local) | shape (world) |
| --- | --- | --- | --- |
| Initial Fabric | \`(0, 0)\` | \`(-3, 3)\` | \`(60, -60)\` |
| → Konva | \`(0, 0)\` | \`(-3, 3)\` | \`(60, -60)\` ✓ |
| → Fabric | \`(-9.125, 9.125)\` | \`(-56.875, 56.875)\` | \`(-3, 3)\` ❌ |

Each Fabric load drifts by approximately the centroid offset. Konva is unaffected — corruption is only on Fabric load.

## After fix

| After | bin | shape |
| --- | --- | --- |
| Initial Fabric | \`(0, 0)\` | \`(-3, 3)\` |
| Konva → Fabric → Konva → Fabric × 3 | \`(0, 0)\` | \`(-3, 3)\` ✓ every sample |

## Test plan

- [ ] Toggle Fabric ↔ Konva several times in a project with a bin containing a shape — positions should not drift
- [ ] Save and reload a project on Fabric — grouped shape positions preserved
- [ ] Save and reload across engine switches — same
- [ ] Existing drag-in / drag-out / drag-between flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)