### PR TITLE
fix(core): preserve child world position across createGroup and updateGroup resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ vite.svg
 .claude/*
 !.claude/commands/
 
+### Playwright MCP testing artifacts
+.playwright-mcp/
+
 ### act (local GitHub Actions)
 act-*.log
 

--- a/src/renderer/src/layout-engine/__tests__/layout-engine.contract.test.ts
+++ b/src/renderer/src/layout-engine/__tests__/layout-engine.contract.test.ts
@@ -259,6 +259,92 @@ describe.each(engineTypes)('LayoutEngine contract (%s)', (engineType) => {
       expect(snap2.x).toBeCloseTo(126, 0)
       expect(snap2.y).toBeCloseTo(84, 0)
     })
+
+    // Helper for issue #279 / #281 / #285: compute a child shape's world
+    // position from its (parent-relative) stored coords.
+    const childWorld = (shape: LayoutShape, group: LayoutGroup): { x: number; y: number } => ({
+      x: group.x + group.width / 2 + shape.x,
+      y: group.y - group.height / 2 + shape.y
+    })
+
+    it('C26 (#279): createGroup with already-existing children preserves their world position', () => {
+      // Bin spans world (84..168, -84..84) → centroid (126, 0).
+      const bin = makeGroup({
+        id: 'bin',
+        x: 84,
+        y: 84,
+        width: 84,
+        height: 84,
+        childIds: []
+      })
+      // Place the rect at world (110, -10) — clearly inside the bin.
+      const rect = makeRect({ id: 'r1', x: 110, y: -10, width: 30, height: 30 })
+
+      engine.addShape(rect)
+      engine.createGroup({ ...bin, childIds: ['r1'] })
+
+      const stored = engine.getShape('r1')!
+      const updatedBin = engine.getGroup('bin')!
+      const world = childWorld(stored, updatedBin)
+      expect(world.x).toBeCloseTo(110, 0)
+      expect(world.y).toBeCloseTo(-10, 0)
+      expect(stored.groupId).toBe('bin')
+    })
+
+    it('C27 (#281): updateGroup({ width, height }) preserves child world position', () => {
+      const bin = makeGroup({ id: 'bin', x: 0, y: 84, width: 84, height: 84 })
+      // Shape at world (40, 40) inside the bin — local (-2, -2) since centroid is (42, 42).
+      const rect = makeRect({ id: 'r1', x: -2, y: -2, width: 20, height: 20, groupId: 'bin' })
+
+      engine.createGroup({ ...bin, childIds: ['r1'] })
+      engine.addShape(rect)
+
+      const before = engine.getShape('r1')!
+      const beforeBin = engine.getGroup('bin')!
+      const beforeWorld = childWorld(before, beforeBin)
+
+      // Grow the bin from 84×84 to 168×168 (lower-left anchored)
+      engine.updateGroup('bin', { width: 168, height: 168 })
+
+      const after = engine.getShape('r1')!
+      const afterBin = engine.getGroup('bin')!
+      const afterWorld = childWorld(after, afterBin)
+      expect(afterWorld.x).toBeCloseTo(beforeWorld.x, 0)
+      expect(afterWorld.y).toBeCloseTo(beforeWorld.y, 0)
+      // Bin's lower-left didn't move; only width/height grew.
+      expect(afterBin.x).toBe(0)
+      expect(afterBin.y).toBe(84)
+      expect(afterBin.width).toBe(168)
+      expect(afterBin.height).toBe(168)
+    })
+
+    it('C28 (#285): toSnapshot → loadSnapshot round-trip preserves grouped shape coords', () => {
+      const bin = makeGroup({ id: 'bin', x: 0, y: 84, width: 84, height: 84 })
+      const rect = makeRect({ id: 'r1', x: -2, y: -2, width: 20, height: 20, groupId: 'bin' })
+
+      engine.createGroup({ ...bin, childIds: ['r1'] })
+      engine.addShape(rect)
+
+      const initial = engine.toSnapshot()
+
+      // Three round-trips — pre-fix this would drift by the bin's centroid
+      // magnitude on each Fabric loadSnapshot.
+      let snapshot = initial
+      for (let i = 0; i < 3; i++) {
+        engine.loadSnapshot(snapshot)
+        snapshot = engine.toSnapshot()
+      }
+
+      const finalBin = snapshot.groups.find((g) => g.id === 'bin')!
+      const finalRect = snapshot.shapes.find((s) => s.id === 'r1')!
+      expect(finalBin.x).toBeCloseTo(0, 0)
+      expect(finalBin.y).toBeCloseTo(84, 0)
+      expect(finalBin.width).toBe(84)
+      expect(finalBin.height).toBe(84)
+      expect(finalRect.x).toBeCloseTo(-2, 0)
+      expect(finalRect.y).toBeCloseTo(-2, 0)
+      expect(finalRect.groupId).toBe('bin')
+    })
   })
 
   // ─── C9-C11: Selection ──────────────────────────────────────────────────────

--- a/src/renderer/src/layout-engine/fabric-engine.ts
+++ b/src/renderer/src/layout-engine/fabric-engine.ts
@@ -377,12 +377,25 @@ export class FabricEngine implements LayoutEngine {
     ;(renderer.fabricGroup as unknown as Record<string, unknown>)[GROUP_DATA_KEY] = group.id
 
     // Move children into group — bypass group.add()/enterGroup to avoid
-    // FitContentLayout corrupting the bin's fixed dimensions.
-    // Shape coords from the snapshot are already in group-local space.
+    // FitContentLayout corrupting the bin's fixed dimensions. Children that
+    // already exist on the canvas (e.g. addShape was called before
+    // createGroup) carry world coords on obj.left/top and must be converted
+    // to group-local before reparenting; skipping the conversion would shift
+    // them by the bin's centroid (issue #279). For the snapshot-restore
+    // path, grouped children aren't in fabricMap yet, so this loop is a
+    // no-op and addShape later attaches them at their already-local coords.
     for (const childId of group.childIds) {
       const obj = this.fabricMap.get(childId)
       if (obj) {
+        const matrix = obj.calcTransformMatrix()
+        const worldX = matrix[4]
+        const worldY = matrix[5]
         this.canvas.remove(obj)
+        const gMatrix = renderer.fabricGroup.calcTransformMatrix()
+        const inv = fabric.util.invertTransform(gMatrix)
+        const localPt = fabric.util.transformPoint(new fabric.Point(worldX, worldY), inv)
+        obj.set({ left: localPt.x, top: localPt.y })
+        obj.setCoords()
         renderer.attachChild(obj)
       }
       const shape = this.shapeMap.get(childId)
@@ -401,7 +414,32 @@ export class FabricEngine implements LayoutEngine {
     const renderer = this.rendererMap.get(id)
     if (!renderer) return
 
+    // Lower-left is anchored across width/height changes, so the bin's
+    // centroid moves by (deltaW/2, -deltaH/2). Children are rendered relative
+    // to the centroid, so without compensation they drift by the same amount
+    // — which is what `Sidebar.handleUpdateBinMetadata` was producing and
+    // what the user-handle resize handler had to correct on its own.
+    // Compensate here so every resize path preserves child world position.
+    const deltaW = (patch.width ?? group.width) - group.width
+    const deltaH = (patch.height ?? group.height) - group.height
+    const dx = -deltaW / 2
+    const dy = deltaH / 2
+
     Object.assign(group, patch, { id })
+
+    if (dx !== 0 || dy !== 0) {
+      const internalObjects = (
+        renderer.fabricGroup as unknown as { _objects: fabric.FabricObject[] }
+      )._objects
+      for (const child of internalObjects) {
+        const rec = child as unknown as Record<string, unknown>
+        if (rec[SHAPE_DATA_KEY]) {
+          child.set({ left: (child.left ?? 0) + dx, top: (child.top ?? 0) + dy })
+          child.setCoords()
+        }
+      }
+    }
+
     renderer.update(patch, group)
     this.emitter.emit('groupChanged', { groupId: id, childIds: [...group.childIds] })
   }

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -551,7 +551,25 @@ export class KonvaEngine implements LayoutEngine {
     const renderer = this.rendererMap.get(id)
     if (!renderer) return
 
+    // Lower-left is anchored across width/height changes, so the bin's
+    // centroid moves by (deltaW/2, -deltaH/2). Children are rendered relative
+    // to the centroid, so without compensation they drift by the same
+    // amount. Compensate here so every resize path (sidebar, programmatic,
+    // user-handle drag) preserves child world position.
+    const deltaW = (patch.width ?? group.width) - group.width
+    const deltaH = (patch.height ?? group.height) - group.height
+    const dx = -deltaW / 2
+    const dy = deltaH / 2
+
     Object.assign(group, patch, { id })
+
+    if (dx !== 0 || dy !== 0) {
+      for (const child of renderer.konvaGroup.getChildren()) {
+        if (child.hasName('__groupBg') || child.hasName('__binArtwork')) continue
+        child.position({ x: child.x() + dx, y: child.y() + dy })
+      }
+    }
+
     renderer.update(patch, group)
     this.emitter.emit('groupChanged', { groupId: id, childIds: [...group.childIds] })
   }


### PR DESCRIPTION
## Summary

Three closely-related grouped-shape positioning issues, all rooted in the same invariant: **a child shape's world position should be preserved across any operation that changes the bin's centroid.** Closes #279, #281, #285.

## What was broken

| # | Issue | Symptom |
| --- | --- | --- |
| #279 | Fabric `createGroup` with already-existing children | Calling `addShape(s); createGroup({childIds: [s.id]})` placed the shape at `world ≈ groupCentroid + drawnPosition` instead of preserving its world position |
| #281 | `updateGroup({ width, height })` doesn't translate children | Sidebar resize (and any programmatic resize via `updateGroup`) drifted child shapes by `(deltaW/2, -deltaH/2)`. Only the user-handle resize handler had its own translation logic |
| #285 | Snapshot round-trip drifting grouped shapes | Already fixed in #284 — this PR adds the regression test |

## Fixes

**Fabric `createGroup`** (existing children path) — read `worldX/Y` via `calcTransformMatrix` before reparenting, convert through inverse group matrix, then `attachChild`. Konva's `createGroup` already did this.

**`updateGroup` in both engines** — when `width` or `height` changes, translate user-shape children by `(-deltaW/2, +deltaH/2)` so the child's world position stays anchored as the centroid moves. Skips bg rect and decorations; only user shapes shift. The user-handle resize path keeps its own translation for now (slight duplication, can be DRYed in a follow-up).

## Tests

Three new contract tests in `layout-engine.contract.test.ts`, run against both engines:

- **C26 (#279)** — `createGroup` with existing child preserves world position
- **C27 (#281)** — `updateGroup({ width, height })` preserves child world position
- **C28 (#285)** — `toSnapshot → loadSnapshot × 3` produces no drift

All 73 contract tests pass on both Fabric and Konva.

## Side improvement

Sidebar bin resize (changing widthUnits/depthUnits) now preserves child shape positions — was previously drifting by the same centroid-delta amount as #281.

## Test plan

- [x] Contract test suite passes on both engines (73/73)
- [ ] Manual: drag a bin resize handle with a shape inside — shape stays put
- [ ] Manual: change widthUnits in sidebar with a shape inside — shape stays put
- [ ] Manual: toggle Fabric ↔ Konva several times with bin+shape — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)