### PR TITLE
ci: fix --publish=never flag dropped by chained build scripts

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -44,17 +44,31 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build macOS
+      # build:mac/win/linux in package.json chain `electron-vite build &&
+      # electron-builder ...`. pnpm cannot forward CLI flags through that
+      # chain — they get dropped — so we invoke the two commands directly.
+      # GH_TOKEN is set so electron-builder's tag-context "implicit publish"
+      # path doesn't crash on a missing token even though we pass --publish=never.
+      - name: Compile renderer + main
+        run: pnpm electron-vite build
+
+      - name: Package macOS
         if: matrix.os == 'macos-latest'
-        run: pnpm run build:mac -- --publish=never
+        run: pnpm electron-builder --mac --publish=never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Windows
+      - name: Package Windows
         if: matrix.os == 'windows-latest'
-        run: pnpm run build:win -- --publish=never
+        run: pnpm electron-builder --win --publish=never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Linux
+      - name: Package Linux
         if: matrix.os == 'ubuntu-latest'
-        run: pnpm run build:linux -- --publish=never
+        run: pnpm electron-builder --linux --publish=never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

The v1.7.0 release build failed on all three platforms with:
> Error: GitHub Personal Access Token is not set, neither programmatically, nor using env \"GH_TOKEN\"

even though the workflow passed \`--publish=never\`.

## Cause

\`build:mac\`/\`build:win\`/\`build:linux\` in package.json chain two commands with \`&&\`:

\`\`\`json
\"build:mac\": \"electron-vite build && electron-builder --mac\"
\`\`\`

When the workflow ran \`pnpm run build:mac -- --publish=never\`, pnpm could not forward the flag through the \`&&\` chain — it landed as a positional arg to the shell wrapper and was **silently dropped**. With no \`--publish\` flag, electron-builder fell back to its tag-context implicit-publish path:

> Implicit publishing triggered by git tag. This behavior will be disabled in electron-builder v27. Please use --publish explicitly.

…and crashed on the missing token.

## Fix

Bypass the chained npm scripts and call \`electron-vite\` + \`electron-builder\` directly in the workflow so flags actually land. Also set \`GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}\` on each package step defensively, so the implicit-publish path doesn't crash if a future change leaves the flag off.

## Test plan

- [ ] After merge, bump to v1.7.1 (release-please will pick up the dep updates) and confirm the matrix build completes.
- [ ] Confirm \`.dmg\`, \`-setup.exe\`, and \`.AppImage\`/\`.deb\`/\`.snap\` show up on the v1.7.1 GitHub release.
- [ ] Confirm \`latest*.yml\` files are uploaded for electron-updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)