### PR TITLE
ci: fix release artifact publish glob and exclude unpacked binaries

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,12 +70,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Only upload installer outputs — exclude dist/win-unpacked, dist/mac-arm64,
+      # etc., so the publish step's globs don't accidentally match unpacked
+      # binaries. if-no-files-found: warn because each runner only produces
+      # the artifacts for its own platform.
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v7
         with:
           name: dist-${{ matrix.os }}
-          path: dist/**
-          if-no-files-found: error
+          path: |
+            dist/*.dmg
+            dist/*.dmg.blockmap
+            dist/*.zip.blockmap
+            dist/*-setup.exe
+            dist/*-setup.exe.blockmap
+            dist/*.AppImage
+            dist/*.deb
+            dist/*.snap
+            dist/latest*.yml
+          if-no-files-found: warn
           retention-days: 7
 
   publish:
@@ -83,6 +96,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      # upload-artifact strips the leading `dist/` prefix when path uses a
+      # wildcard, so artifact contents are flat. With merge-multiple the
+      # download lands files directly in the workflow workspace — patterns
+      # below match files in cwd, not under dist/.
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
@@ -93,12 +110,14 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            **/dist/gridfinity-studio-*-setup.exe
-            **/dist/gridfinity-studio-*.dmg
-            **/dist/gridfinity-studio-*.AppImage
-            **/dist/*.deb
-            **/dist/*.snap
-            **/dist/latest*.yml
-            **/dist/*.blockmap
+            *-setup.exe
+            *-setup.exe.blockmap
+            *.dmg
+            *.dmg.blockmap
+            *.zip.blockmap
+            *.AppImage
+            *.deb
+            *.snap
+            latest*.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The v1.7.1 build succeeded on all three platforms but the **publish** step uploaded **zero artifacts** to the release — the file globs missed everything. I uploaded v1.7.1 manually via \`gh release upload\` to ship; this PR fixes the workflow so future releases auto-publish.

## Cause

Two bugs:

1. **\`upload-artifact\` strips the wildcard prefix.** With \`path: dist/**\` the leading \`dist/\` becomes the artifact root and gets stripped, so the artifact contents are flat (\`gridfinity-studio-1.7.1.dmg\`, not \`dist/gridfinity-studio-1.7.1.dmg\`). After \`download-artifact\` with \`merge-multiple: true\` extracts the files into the workflow workspace, the \`**/dist/...\` globs match nothing.

2. **\`dist/**\` also pulls in intermediate directories** like \`dist/win-unpacked/gridfinity-studio.exe\`, which would surface as a fake \`*.exe\` after merge.

## Fix

- Tighten the upload glob to enumerate the installer file types we actually want — no more unpacked binaries leaking through.
- Update the publish patterns to match files at workflow root (no \`**/dist/\` prefix).
- Switch \`if-no-files-found\` from \`error\` to \`warn\` — each runner only produces installers for its own platform.

Both changes are documented inline in the workflow.

## Test plan

- [ ] Merge → cut a small follow-up release (or wait for next legitimate one)
- [ ] Confirm \`Build for Release\` runs all three platforms green
- [ ] Confirm the new release page lists the same 11 assets that were manually uploaded to v1.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)