### PR TITLE
ci: add actionlint workflow

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,15 @@
+name: Lint Workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.12


### PR DESCRIPTION
## Summary

Adds \`lint-workflows.yml\` so any change under \`.github/workflows/\` runs actionlint and fails fast on workflow-syntax bugs.

The publish-glob mismatch that hid v1.7.1's release artifacts (fixed in #304) was exactly the kind of thing actionlint would have caught earlier.

## Why this is the only change

I originally also tried adopting the shared \`commitlint.yml\` and \`ci.yml\` from \`unstable-studios/.github\` in this PR but reverted that part:

- The shared **commitlint** workflow passes \`version: 10\` to \`pnpm/action-setup\`, which conflicts with this repo's \`package.json\` \`packageManager\` field — pnpm errors with \`ERR_PNPM_BAD_PM_VERSION\`.
- The shared **ci** matrix-mode job didn't surface at all in CI (jobs never appeared in the run); likely a concurrency-group collision between the caller and the callee, but worth investigating upstream rather than in this repo.

Both look fixable with a small change in \`unstable-studios/.github\` (make \`pnpm-version\` default to empty so it falls back to \`packageManager\`, and namespace the shared workflow's concurrency group). I'd open that PR separately and re-attempt the migration after.

## Test plan

- [ ] CI on this PR runs actionlint green
- [ ] Edit any workflow file in a follow-up PR and confirm actionlint runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)