### PR TITLE
ci: bump deprecated actions to Node 24 and ship mac auto-update zip

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -81,6 +81,7 @@ jobs:
           path: |
             dist/*.dmg
             dist/*.dmg.blockmap
+            dist/*-mac.zip
             dist/*.zip.blockmap
             dist/*-setup.exe
             dist/*-setup.exe.blockmap
@@ -107,13 +108,14 @@ jobs:
           merge-multiple: true
 
       - name: Upload Release Asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             *-setup.exe
             *-setup.exe.blockmap
             *.dmg
             *.dmg.blockmap
+            *-mac.zip
             *.zip.blockmap
             *.AppImage
             *.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -56,7 +56,7 @@ jobs:
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -73,7 +73,7 @@ jobs:
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -91,7 +91,7 @@ jobs:
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
## Summary

Two unrelated CI fixes, bundled because they're both small and touch only workflows.

### 1. Node 20 deprecation

GitHub flagged \`pnpm/action-setup@v4\` and \`softprops/action-gh-release@v2\` as Node 20 actions in our last release runs. Bumping to:

- \`pnpm/action-setup@v6\` (Node 24)
- \`softprops/action-gh-release@v3\` (Node 24)

Both are major bumps — neither has breaking changes that affect our usage:

- \`pnpm/action-setup@v6\` still reads version from \`packageManager\` in package.json the same way; the major bumps were Node version drops.
- \`softprops/action-gh-release@v3\` keeps the same input names; the major bump was Node 24 + a few permission tightenings we already satisfy.

### 2. macOS auto-update zip missing from releases

The v1.7.2 release shipped \`gridfinity-studio-1.7.2-arm64-mac.zip.blockmap\` **without the matching .zip** because the upload glob in #304 listed \`*.zip.blockmap\` but not \`*-mac.zip\`. electron-updater downloads the zip (not the dmg) on macOS auto-updates, so \`latest-mac.yml\` points to a missing file and updates fail silently.

Adds \`dist/*-mac.zip\` to both the upload-artifact path and the release-asset publish glob. Next release will include the actual zip.

## Test plan

- [ ] Merge → next release auto-published cuts a complete asset list including the mac \`-arm64-mac.zip\`
- [ ] Confirm Node 20 deprecation warnings no longer show in the build logs
- [ ] Confirm electron-updater on macOS can resolve \`latest-mac.yml\` and download an update

🤖 Generated with [Claude Code](https://claude.com/claude-code)