### PR TITLE
fix: prep for React monorepo + TypeScript 6 bumps

### DIFF
--- a/src/renderer/src/hooks/useBinBaker.ts
+++ b/src/renderer/src/hooks/useBinBaker.ts
@@ -179,13 +179,19 @@ export function useBinBaker(enabled: boolean): void {
   // Bin IDs we've previously baked, to detect deletions.
   const lastSeenBinIdsRef = useRef<Set<string>>(new Set())
   // Stable refs to the bake function and store setters so the closure inside
-  // the in-flight resolution path doesn't capture stale values.
+  // the in-flight resolution path doesn't capture stale values. Synced via
+  // useEffect (rather than during render) so the new react-hooks/refs rule
+  // is satisfied; the resolver runs asynchronously, so the small delay
+  // before refs update post-commit is fine.
   const bakePocketsRef = useRef(bakePockets)
   const setBakeResultRef = useRef(setBakeResult)
   const setBakeStatusRef = useRef(setBakeStatus)
-  bakePocketsRef.current = bakePockets
-  setBakeResultRef.current = setBakeResult
-  setBakeStatusRef.current = setBakeStatus
+
+  useEffect(() => {
+    bakePocketsRef.current = bakePockets
+    setBakeResultRef.current = setBakeResult
+    setBakeStatusRef.current = setBakeStatus
+  })
 
   useEffect(() => {
     if (!engine || !ready || !enabled) return

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -29,13 +29,12 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "composite": true,
-    "baseUrl": ".",
     "paths": {
       "@renderer/*": [
-        "src/renderer/src/*"
+        "./src/renderer/src/*"
       ],
       "@/*": [
-        "src/renderer/src/*"
+        "./src/renderer/src/*"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Two unrelated forward-compat fixes that the in-flight Renovate PRs need to pass CI:

- **#307** (React monorepo) — eslint-plugin-react-hooks v5+ adds a \`react-hooks/refs\` rule that flags \`*Ref.current = ...\` during render. \`useBinBaker.ts\` was doing this to keep refs synced with the latest store setters and bake function.

- **#314** (typescript v6) — TS 6 makes \`"baseUrl": "."\` an error (TS5101) that stops working entirely in TS 7.

## Fixes

1. \`useBinBaker.ts\` — move the ref-sync assignments into a \`useEffect\`. The in-flight bake resolver runs asynchronously, so the tiny delay before refs update post-commit is harmless.
2. \`tsconfig.web.json\` — drop \`baseUrl\`, prefix \`paths\` values with \`./\` so they resolve relative to tsconfig. Works in TS 5 today and forward-compatible with TS 6+.

Verified locally: lint, typecheck, and full build all pass.

## Holding pattern for the other Renovate majors

- **#311** (\`@vitejs/plugin-react\` v6) — imports \`vite/internal\` which doesn't exist in Vite 7; needs an upstream patch or wait.
- **#313** (electron v41) — \`node-abi\` doesn't recognize Electron 41's ABI; electron-builder dies during install. Needs an electron-builder/node-abi update.

Both are tracked separately — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)