### PR TITLE
ci: sign and notarize macOS builds via App Store Connect API

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -52,11 +52,35 @@ jobs:
       - name: Compile renderer + main
         run: pnpm electron-vite build
 
+      # Decode the App Store Connect API key (.p8) to a file so electron-builder
+      # can point notarytool at it via APPLE_API_KEY. Stored as a base64 secret
+      # to survive newlines in the PEM-formatted key.
+      - name: Write Apple API key
+        if: matrix.os == 'macos-latest' && env.APPLE_API_KEY_BASE64 != ''
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/apple"
+          printf '%s' "$APPLE_API_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/apple/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/apple/AuthKey.p8"
+          echo "APPLE_API_KEY=$RUNNER_TEMP/apple/AuthKey.p8" >> "$GITHUB_ENV"
+
       - name: Package macOS
         if: matrix.os == 'macos-latest'
         run: pnpm electron-builder --mac --publish=never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Code signing — electron-builder imports CSC_LINK (.p12) into a temp
+          # keychain on the runner. If unset (no signing secrets configured),
+          # electron-builder produces an unsigned build instead of failing.
+          CSC_LINK: ${{ secrets.MAC_CERTS_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+          # Notarization (App Store Connect API key — preferred over Apple ID +
+          # app-specific password since it doesn't require MFA). APPLE_API_KEY
+          # is exported in the previous step.
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Package Windows
         if: matrix.os == 'windows-latest'

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -23,7 +23,11 @@ mac:
   extendInfo:
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: false
+  # Notarize on CI when APPLE_TEAM_ID + APPLE_API_KEY* env vars are present.
+  # If they're missing (e.g. local dev build), electron-builder skips signing
+  # entirely and notarize is a no-op — so this stays compatible with unsigned
+  # local builds.
+  notarize: true
 dmg:
   artifactName: ${name}-${version}.${ext}
 linux:


### PR DESCRIPTION
## Summary

Wires up macOS code signing + notarization so distributed \`.dmg\`/\`.zip\` artifacts launch on user machines without Gatekeeper warnings and electron-updater can ship updates.

Closes #227 (macOS path).

## Workflow

- \`electron-builder.yml\`: \`notarize: true\`. With \`APPLE_TEAM_ID\` + \`APPLE_API_KEY*\` env vars present, electron-builder runs notarytool after signing. With them missing (local dev), signing is skipped entirely so the existing unsigned-local-build flow keeps working.
- \`build-release.yml\`: decode the App Store Connect \`.p8\` key (base64 secret) to a temp file, then point \`APPLE_API_KEY\` at it. Pass \`CSC_LINK\` + \`CSC_KEY_PASSWORD\` for the Developer ID Application cert.

## Required GitHub secrets

Add these at \`Settings → Secrets and variables → Actions → Repository secrets\`:

| Secret | Source |
|---|---|
| \`MAC_CERTS_BASE64\` | Developer ID Application \`.p12\` export, base64-encoded |
| \`MAC_CERTS_PASSWORD\` | The \`.p12\` export password |
| \`APPLE_API_KEY_BASE64\` | App Store Connect \`.p8\` private key, base64-encoded |
| \`APPLE_API_KEY_ID\` | 10-char Key ID from App Store Connect |
| \`APPLE_API_ISSUER\` | Issuer UUID from App Store Connect |
| \`APPLE_TEAM_ID\` | 10-char team ID from developer.apple.com → Membership |

See follow-up comment for the step-by-step on generating these.

## Test plan

- [ ] Add the 6 secrets above to the repository
- [ ] Merge this PR
- [ ] Cut a v1.7.3 release
- [ ] Confirm the build-release workflow's macOS job:
  - Imports cert into the temp keychain (no \`code signing identity not found\` errors)
  - Runs notarytool successfully (look for \`✓ notarization complete\` in logs)
  - Produces a stapled \`.dmg\` and \`-arm64-mac.zip\`
- [ ] Download the \`.dmg\` on a fresh Mac, confirm it launches without right-click → Open
- [ ] Run \`spctl --assess --type execute /Applications/gridfinity-studio.app\` and verify \`accepted\` + \`Notarized Developer ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)