### PR TITLE
feat(core): route autoUpdater logs through electron-log

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "earcut": "^3.0.2",
+    "electron-log": "^5.4.3",
     "electron-updater": "^6.8.3",
     "fabric": "^7.2.0",
     "jszip": "^3.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       earcut:
         specifier: ^3.0.2
         version: 3.0.2
+      electron-log:
+        specifier: ^5.4.3
+        version: 5.4.3
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.3
@@ -2411,6 +2414,19 @@ packages:
       shiki: '>=1.0.0'
       tailwindcss: '>=4.2.1'
       vitest: '>=4.1.0'
+    peerDependenciesMeta:
+      '@unstable-studios/docs':
+        optional: true
+      '@unstable-studios/file-picker':
+        optional: true
+      '@unstable-studios/notifications':
+        optional: true
+      '@unstable-studios/templating':
+        optional: true
+      shiki:
+        optional: true
+      vitest:
+        optional: true
 
   '@uppy/components@1.2.0':
     resolution: {integrity: sha512-rtIr+77Rw/q5Vw++xazF1dCg2d4A4zT9CV+ZyN8Rsx8xiIr2CxCR4TaHHBy+WeC0b7Mk6yNuJ0wUa34tFJ6pKg==, tarball: https://registry.npmjs.org/@uppy/components/-/components-1.2.0.tgz}
@@ -3229,6 +3245,10 @@ packages:
     resolution: {integrity: sha512-7BEeGz8Xlk7Qvitj70nGAQaq7WQIZ2amsDvsyKSZbxgtL2pM9fm/woZrtn0hoID6Fl7wkn456dK3OmtFNzgiOA==, tarball: https://registry.npmjs.org/electron-builder/-/electron-builder-26.9.0.tgz}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  electron-log@5.4.3:
+    resolution: {integrity: sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==, tarball: https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz}
+    engines: {node: '>= 14'}
 
   electron-publish@26.9.0:
     resolution: {integrity: sha512-gsy+U7JfDuD1lPOrCXeECDQoUsWjFah3s1Fv3pqKnjdJuKYDDvGdvC74kLHVG6nl5G0uQ7YN0eftCQ4rUmhvVw==, tarball: https://registry.npmjs.org/electron-publish/-/electron-publish-26.9.0.tgz}
@@ -5921,7 +5941,8 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@cloudflare/workers-types@4.20260501.1': {}
+  '@cloudflare/workers-types@4.20260501.1':
+    optional: true
 
   '@commitlint/cli@20.5.3(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
@@ -7428,38 +7449,46 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
+    optional: true
 
   '@shikijs/engine-javascript@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
+    optional: true
 
   '@shikijs/engine-oniguruma@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
+    optional: true
 
   '@shikijs/langs@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
+    optional: true
 
   '@shikijs/primitive@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+    optional: true
 
   '@shikijs/themes@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
+    optional: true
 
   '@shikijs/types@4.0.2':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+    optional: true
 
-  '@shikijs/vscode-textmate@10.0.2': {}
+  '@shikijs/vscode-textmate@10.0.2':
+    optional: true
 
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
@@ -7625,7 +7654,8 @@ snapshots:
 
   '@tanstack/virtual-core@3.14.0': {}
 
-  '@transloadit/prettier-bytes@0.3.5': {}
+  '@transloadit/prettier-bytes@0.3.5':
+    optional: true
 
   '@tweenjs/tween.js@23.1.3': {}
 
@@ -7665,6 +7695,7 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+    optional: true
 
   '@types/http-cache-semantics@4.2.0': {}
 
@@ -7677,6 +7708,7 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+    optional: true
 
   '@types/ms@2.1.0': {}
 
@@ -7725,7 +7757,8 @@ snapshots:
       fflate: 0.8.2
       meshoptimizer: 1.1.1
 
-  '@types/unist@3.0.3': {}
+  '@types/unist@3.0.3':
+    optional: true
 
   '@types/verror@1.10.11':
     optional: true
@@ -7836,6 +7869,7 @@ snapshots:
       fflate: 0.8.2
       hono: 4.12.16
       react: 19.2.5
+    optional: true
 
   '@unstable-studios/file-picker@1.2.2(@cloudflare/workers-types@4.20260501.1)(@uppy/core@5.2.0)(@uppy/react@5.2.0(@uppy/core@5.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(aws4fetch@1.0.20)(hono@4.12.16)(react@19.2.5)':
     dependencies:
@@ -7845,15 +7879,18 @@ snapshots:
       aws4fetch: 1.0.20
       hono: 4.12.16
       react: 19.2.5
+    optional: true
 
   '@unstable-studios/notifications@1.1.1(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260501.1))(react@19.2.5)':
     dependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260501.1)
       react: 19.2.5
+    optional: true
 
   '@unstable-studios/templating@1.1.3(react@19.2.5)':
     dependencies:
       react: 19.2.5
+    optional: true
 
   '@unstable-studios/ui@1.6.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@unstable-studios/docs@1.1.1(@cloudflare/workers-types@4.20260501.1)(hono@4.12.16)(react@19.2.5))(@unstable-studios/file-picker@1.2.2(@cloudflare/workers-types@4.20260501.1)(@uppy/core@5.2.0)(@uppy/react@5.2.0(@uppy/core@5.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(aws4fetch@1.0.20)(hono@4.12.16)(react@19.2.5))(@unstable-studios/notifications@1.1.1(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260501.1))(react@19.2.5))(@unstable-studios/templating@1.1.3(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@4.0.2)(tailwindcss@4.2.4)(vitest@4.1.5)':
     dependencies:
@@ -7861,20 +7898,21 @@ snapshots:
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@unstable-studios/docs': 1.1.1(@cloudflare/workers-types@4.20260501.1)(hono@4.12.16)(react@19.2.5)
-      '@unstable-studios/file-picker': 1.2.2(@cloudflare/workers-types@4.20260501.1)(@uppy/core@5.2.0)(@uppy/react@5.2.0(@uppy/core@5.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(aws4fetch@1.0.20)(hono@4.12.16)(react@19.2.5)
-      '@unstable-studios/notifications': 1.1.1(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260501.1))(react@19.2.5)
-      '@unstable-studios/templating': 1.1.3(react@19.2.5)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lucide-react: 0.577.0(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      shiki: 4.0.2
       sonner: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge: 3.5.0
       tailwindcss: 4.2.4
+    optionalDependencies:
+      '@unstable-studios/docs': 1.1.1(@cloudflare/workers-types@4.20260501.1)(hono@4.12.16)(react@19.2.5)
+      '@unstable-studios/file-picker': 1.2.2(@cloudflare/workers-types@4.20260501.1)(@uppy/core@5.2.0)(@uppy/react@5.2.0(@uppy/core@5.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(aws4fetch@1.0.20)(hono@4.12.16)(react@19.2.5)
+      '@unstable-studios/notifications': 1.1.1(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260501.1))(react@19.2.5)
+      '@unstable-studios/templating': 1.1.3(react@19.2.5)
+      shiki: 4.0.2
       vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0(canvas@3.2.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -7887,6 +7925,7 @@ snapshots:
       dequal: 2.0.3
       preact: 10.29.1
       pretty-bytes: 6.1.1
+    optional: true
 
   '@uppy/core@5.2.0':
     dependencies:
@@ -7898,6 +7937,7 @@ snapshots:
       namespace-emitter: 2.0.1
       nanoid: 5.1.11
       preact: 10.29.1
+    optional: true
 
   '@uppy/react@5.2.0(@uppy/core@5.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -7909,13 +7949,16 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.5)
     transitivePeerDependencies:
       - '@uppy/image-editor'
+    optional: true
 
-  '@uppy/store-default@5.0.0': {}
+  '@uppy/store-default@5.0.0':
+    optional: true
 
   '@uppy/utils@7.2.0':
     dependencies:
       lodash: 4.18.1
       preact: 10.29.1
+    optional: true
 
   '@use-gesture/core@10.3.1': {}
 
@@ -8169,7 +8212,8 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  aws4fetch@1.0.20: {}
+  aws4fetch@1.0.20:
+    optional: true
 
   balanced-match@1.0.2: {}
 
@@ -8315,7 +8359,8 @@ snapshots:
       prebuild-install: 7.1.3
     optional: true
 
-  ccount@2.0.1: {}
+  ccount@2.0.1:
+    optional: true
 
   chai@6.2.2: {}
 
@@ -8330,9 +8375,11 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  character-entities-html4@2.1.0: {}
+  character-entities-html4@2.1.0:
+    optional: true
 
-  character-entities-legacy@3.0.0: {}
+  character-entities-legacy@3.0.0:
+    optional: true
 
   chardet@0.7.0: {}
 
@@ -8411,7 +8458,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
-  comma-separated-tokens@2.0.3: {}
+  comma-separated-tokens@2.0.3:
+    optional: true
 
   commander@13.1.0: {}
 
@@ -8604,7 +8652,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  dequal@2.0.3: {}
+  dequal@2.0.3:
+    optional: true
 
   detect-file@1.0.0: {}
 
@@ -8624,6 +8673,7 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+    optional: true
 
   dir-compare@4.2.0:
     dependencies:
@@ -8683,6 +8733,7 @@ snapshots:
   drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260501.1):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260501.1
+    optional: true
 
   dunder-proto@1.0.1:
     dependencies:
@@ -8720,6 +8771,8 @@ snapshots:
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
+
+  electron-log@5.4.3: {}
 
   electron-publish@26.9.0:
     dependencies:
@@ -9521,10 +9574,12 @@ snapshots:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
+    optional: true
 
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+    optional: true
 
   hermes-estree@0.25.1: {}
 
@@ -9538,7 +9593,8 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.16: {}
+  hono@4.12.16:
+    optional: true
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -9551,7 +9607,8 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-void-elements@3.0.0: {}
+  html-void-elements@3.0.0:
+    optional: true
 
   http-cache-semantics@4.2.0: {}
 
@@ -10102,6 +10159,7 @@ snapshots:
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+    optional: true
 
   meow@13.2.0: {}
 
@@ -10117,18 +10175,23 @@ snapshots:
     dependencies:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+    optional: true
 
-  micromark-util-encode@2.0.1: {}
+  micromark-util-encode@2.0.1:
+    optional: true
 
   micromark-util-sanitize-uri@2.0.1:
     dependencies:
       micromark-util-character: 2.1.1
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
+    optional: true
 
-  micromark-util-symbol@2.0.1: {}
+  micromark-util-symbol@2.0.1:
+    optional: true
 
-  micromark-util-types@2.0.2: {}
+  micromark-util-types@2.0.2:
+    optional: true
 
   micromatch@4.0.8:
     dependencies:
@@ -10140,6 +10203,7 @@ snapshots:
   mime-match@1.0.2:
     dependencies:
       wildcard: 1.1.2
+    optional: true
 
   mime-types@2.1.35:
     dependencies:
@@ -10212,11 +10276,13 @@ snapshots:
 
   mute-stream@1.0.0: {}
 
-  namespace-emitter@2.0.1: {}
+  namespace-emitter@2.0.1:
+    optional: true
 
   nanoid@3.3.12: {}
 
-  nanoid@5.1.11: {}
+  nanoid@5.1.11:
+    optional: true
 
   napi-build-utils@2.0.0:
     optional: true
@@ -10345,13 +10411,15 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  oniguruma-parser@0.12.2: {}
+  oniguruma-parser@0.12.2:
+    optional: true
 
   oniguruma-to-es@4.3.6:
     dependencies:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+    optional: true
 
   optionator@0.9.4:
     dependencies:
@@ -10464,7 +10532,8 @@ snapshots:
 
   potpack@1.0.2: {}
 
-  preact@10.29.1: {}
+  preact@10.29.1:
+    optional: true
 
   prebuild-install@7.1.3:
     dependencies:
@@ -10490,7 +10559,8 @@ snapshots:
 
   prettier@3.8.3: {}
 
-  pretty-bytes@6.1.1: {}
+  pretty-bytes@6.1.1:
+    optional: true
 
   proc-log@6.1.0: {}
 
@@ -10522,7 +10592,8 @@ snapshots:
 
   property-graph@4.1.0: {}
 
-  property-information@7.1.0: {}
+  property-information@7.1.0:
+    optional: true
 
   pump@3.0.4:
     dependencies:
@@ -10650,12 +10721,15 @@ snapshots:
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
+    optional: true
 
-  regex-utilities@2.3.0: {}
+  regex-utilities@2.3.0:
+    optional: true
 
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+    optional: true
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -10916,6 +10990,7 @@ snapshots:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+    optional: true
 
   side-channel-list@1.0.1:
     dependencies:
@@ -10992,7 +11067,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  space-separated-tokens@2.0.2: {}
+  space-separated-tokens@2.0.2:
+    optional: true
 
   sprintf-js@1.1.3:
     optional: true
@@ -11077,6 +11153,7 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -11232,7 +11309,8 @@ snapshots:
       punycode: 2.3.1
     optional: true
 
-  trim-lines@3.0.1: {}
+  trim-lines@3.0.1:
+    optional: true
 
   troika-three-text@0.52.4(three@0.184.0):
     dependencies:
@@ -11348,25 +11426,30 @@ snapshots:
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
+    optional: true
 
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
+    optional: true
 
   unist-util-stringify-position@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
+    optional: true
 
   unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
+    optional: true
 
   unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+    optional: true
 
   universalify@0.1.2: {}
 
@@ -11418,11 +11501,13 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
+    optional: true
 
   vfile@6.0.3:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+    optional: true
 
   vite-plugin-electron@0.29.1: {}
 
@@ -11577,7 +11662,8 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wildcard@1.1.2: {}
+  wildcard@1.1.2:
+    optional: true
 
   word-wrap@1.2.5: {}
 
@@ -11654,4 +11740,5 @@ snapshots:
       react: 19.2.5
       use-sync-external-store: 1.6.0(react@19.2.5)
 
-  zwitch@2.0.4: {}
+  zwitch@2.0.4:
+    optional: true

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { readFileSync, writeFileSync } from 'fs'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { autoUpdater } from 'electron-updater'
+import log from 'electron-log/main'
 import icon from '../../resources/icon.png?asset'
 import {
   saveProject,
@@ -186,10 +187,21 @@ app.whenReady().then(() => {
   // needed. Disabled in dev so it doesn't try to fetch a release from GitHub
   // every time we run pnpm dev.
   if (!is.dev) {
+    // Route electron-updater's internal logs through electron-log so they
+    // land in ~/Library/Logs/gridfinity-studio/main.log on macOS (platform
+    // equivalent elsewhere). Without this, autoUpdater falls back to
+    // console.log which is invisible in a packaged Mac app launched from
+    // Finder/Spotlight. Only the updater logger and our explicit log.error
+    // calls below go through the file — other console.* in main still go to
+    // stdout.
+    log.initialize()
+    log.transports.file.level = 'info'
+    autoUpdater.logger = log
+
     autoUpdater.autoDownload = true
     autoUpdater.autoInstallOnAppQuit = true
     autoUpdater.on('error', (err) => {
-      console.error('[autoUpdater]', err)
+      log.error('[autoUpdater]', err)
     })
     void autoUpdater.checkForUpdatesAndNotify()
     setInterval(


### PR DESCRIPTION
Without a configured logger, electron-updater falls back to `console.log`, which is invisible in a packaged Mac app launched from Finder or Spotlight — making it impossible to see why an update did or didn't fire without launching from a terminal.

## Change

- Add `electron-log` dep
- In `src/main/index.ts`, behind `!is.dev`:
  - `log.initialize()`
  - Set `autoUpdater.logger = log`
  - Replace the manual `console.error` in our error handler with `log.error`

## Effect

All update activity now lands at `~/Library/Logs/gridfinity-studio/main.log` on macOS (and the platform equivalent on Windows/Linux). Tail it to watch update flow in real time:

```
tail -F ~/Library/Logs/gridfinity-studio/main.log
```

Dev mode is unchanged — file logging only kicks in for production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)