### PR TITLE
feat(ui): surface auto-update status in the Help menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { readFileSync, writeFileSync } from 'fs'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { autoUpdater } from 'electron-updater'
 import log from 'electron-log/main'
+import { IDLE_STATE, UPDATE_CHANNELS, type UpdateState } from '../shared/types/updates'
 import icon from '../../resources/icon.png?asset'
 import {
   saveProject,
@@ -174,6 +175,25 @@ app.whenReady().then(() => {
     return exportBatch(win, files)
   })
 
+  // Update IPC: renderer can read current state and trigger install. Register
+  // BEFORE createWindow() so the renderer's mount-time getState() call can't
+  // race ahead of `ipcMain.handle` and reject.
+  let updateState: UpdateState = IDLE_STATE
+  const broadcast = (next: UpdateState): void => {
+    updateState = next
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send(UPDATE_CHANNELS.state, next)
+    }
+  }
+  ipcMain.handle(UPDATE_CHANNELS.getState, () => updateState)
+  ipcMain.handle(UPDATE_CHANNELS.installNow, () => {
+    // Guard: only valid when an update is staged AND we're in a real packaged
+    // build. Calling quitAndInstall outside those conditions would be a
+    // surprising restart triggered by an exposed IPC channel.
+    if (is.dev || updateState.kind !== 'downloaded') return
+    autoUpdater.quitAndInstall(false, true)
+  })
+
   createWindow()
 
   app.on('activate', function () {
@@ -200,9 +220,24 @@ app.whenReady().then(() => {
 
     autoUpdater.autoDownload = true
     autoUpdater.autoInstallOnAppQuit = true
+
+    autoUpdater.on('checking-for-update', () => broadcast({ kind: 'checking' }))
+    autoUpdater.on('update-not-available', () => broadcast(IDLE_STATE))
+    autoUpdater.on('update-available', (info) => {
+      broadcast({ kind: 'downloading', version: info.version, progress: 0 })
+    })
+    autoUpdater.on('download-progress', (info) => {
+      const version = updateState.kind === 'downloading' ? updateState.version : ''
+      broadcast({ kind: 'downloading', version, progress: info.percent })
+    })
+    autoUpdater.on('update-downloaded', (info) => {
+      broadcast({ kind: 'downloaded', version: info.version })
+    })
     autoUpdater.on('error', (err) => {
       log.error('[autoUpdater]', err)
+      broadcast({ kind: 'error', message: err.message ?? String(err) })
     })
+
     void autoUpdater.checkForUpdatesAndNotify()
     setInterval(
       () => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,5 +1,12 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
 import type { ProjectData } from '../shared/types/project'
+import type { UpdateState } from '../shared/types/updates'
+
+interface UpdatesAPI {
+  getState: () => Promise<UpdateState>
+  onStateChange: (handler: (state: UpdateState) => void) => () => void
+  installNow: () => Promise<void>
+}
 
 interface ProjectAPI {
   save: (
@@ -31,6 +38,7 @@ declare global {
     api: {
       project: ProjectAPI
       export: ExportAPI
+      updates: UpdatesAPI
     }
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 import type { ProjectData } from '../shared/types/project'
+import { UPDATE_CHANNELS, type UpdateState } from '../shared/types/updates'
 
 // Custom APIs for renderer
 const api = {
@@ -17,6 +18,18 @@ const api = {
     threemf: (data: ArrayBuffer) => ipcRenderer.invoke('export:3mf', data),
     batch: (files: Array<{ filename: string; data: ArrayBuffer }>) =>
       ipcRenderer.invoke('export:batch', files)
+  },
+  updates: {
+    /** Read the current update state (renderer may mount after main has emitted). */
+    getState: (): Promise<UpdateState> => ipcRenderer.invoke(UPDATE_CHANNELS.getState),
+    /** Subscribe to state changes. Returns an unsubscribe function. */
+    onStateChange: (handler: (state: UpdateState) => void): (() => void) => {
+      const listener = (_: Electron.IpcRendererEvent, state: UpdateState): void => handler(state)
+      ipcRenderer.on(UPDATE_CHANNELS.state, listener)
+      return () => ipcRenderer.off(UPDATE_CHANNELS.state, listener)
+    },
+    /** Quit and install the downloaded update. Only meaningful when state is 'downloaded'. */
+    installNow: (): Promise<void> => ipcRenderer.invoke(UPDATE_CHANNELS.installNow)
   }
 }
 

--- a/src/renderer/src/components/Navbar.tsx
+++ b/src/renderer/src/components/Navbar.tsx
@@ -24,6 +24,8 @@ import NewProjectDialog from '@/components/settings/NewProjectDialog'
 import { useProject } from '@/hooks/useProject'
 import { useUndoRedo } from '@/hooks/useUndoRedo'
 import { useAppMode } from '@/hooks/useAppMode'
+import { useAppUpdate } from '@/hooks/useAppUpdate'
+import type { UpdateState } from '../../../shared/types/updates'
 import { buildSTLArrayBuffer, build3MFArrayBuffer, placementsFromGroups } from '@/lib/export-baked'
 import { useLayoutEngine, useEngineState, isBinGroup } from '@/layout-engine'
 import {
@@ -134,6 +136,7 @@ function AppMenubar({
   } = useProject()
   const { undo, redo, canUndo, canRedo } = useUndoRedo()
   const projectName = useProjectName()
+  const { state: updateState, installNow } = useAppUpdate()
 
   useEffect(() => {
     loadRecentProjects()
@@ -266,7 +269,10 @@ function AppMenubar({
 
       {/* ── Help ── */}
       <MenubarMenu>
-        <MenubarTrigger>Help</MenubarTrigger>
+        <MenubarTrigger className="relative">
+          Help
+          <UpdateBadge state={updateState} />
+        </MenubarTrigger>
         <MenubarContent onCloseAutoFocus={(e) => e.preventDefault()}>
           <MenubarItem onSelect={() => window.open(GITHUB_REPO, '_blank')}>
             Documentation
@@ -278,6 +284,7 @@ function AppMenubar({
           <MenubarItem disabled className="opacity-80 cursor-default">
             Version {__APP_VERSION__}
           </MenubarItem>
+          <UpdateStatusMenuItem state={updateState} onInstallNow={installNow} />
         </MenubarContent>
       </MenubarMenu>
     </Menubar>
@@ -367,5 +374,90 @@ function ToolBar() {
         </ToggleGroupItem>
       ))}
     </ToggleGroup>
+  )
+}
+
+// ─── Update status helpers ──────────────────────────────────────────────────
+
+/**
+ * Decorative dot on the Help menu trigger when an update is downloading,
+ * ready, or errored. Hidden from screen readers — the actual textual status
+ * lives inside the menu (UpdateStatusMenuItem) and in an sr-only label here.
+ */
+function badgeStyle(state: UpdateState): { color: string; srLabel: string } | null {
+  switch (state.kind) {
+    case 'downloading':
+      return { color: 'bg-blue-500', srLabel: 'Update downloading' }
+    case 'downloaded':
+      return { color: 'bg-green-500', srLabel: 'Update ready to install' }
+    case 'error':
+      return { color: 'bg-red-500', srLabel: 'Update check failed' }
+    default:
+      return null
+  }
+}
+
+function UpdateBadge({ state }: { state: UpdateState }): React.JSX.Element | null {
+  const style = badgeStyle(state)
+  if (!style) return null
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className={`absolute right-1 top-1 h-1.5 w-1.5 rounded-full ${style.color}`}
+      />
+      <span className="sr-only">{style.srLabel}</span>
+    </>
+  )
+}
+
+function UpdateStatusMenuItem({
+  state,
+  onInstallNow
+}: {
+  state: UpdateState
+  onInstallNow: () => void
+}): React.JSX.Element | null {
+  if (state.kind === 'idle') return null
+
+  if (state.kind === 'checking') {
+    return (
+      <MenubarItem disabled className="opacity-70 cursor-default text-xs">
+        Checking for updates…
+      </MenubarItem>
+    )
+  }
+
+  if (state.kind === 'downloading') {
+    const pct = Math.max(0, Math.min(100, Math.round(state.progress)))
+    const label = state.version
+      ? `Downloading v${state.version}… ${pct}%`
+      : `Downloading update… ${pct}%`
+    return (
+      <MenubarItem disabled className="opacity-70 cursor-default text-xs">
+        {label}
+      </MenubarItem>
+    )
+  }
+
+  if (state.kind === 'downloaded') {
+    return (
+      <MenubarItem
+        onSelect={(e) => {
+          e.preventDefault()
+          onInstallNow()
+        }}
+        className="text-xs text-green-600 dark:text-green-400 font-medium"
+      >
+        v{state.version} ready — Restart to apply
+      </MenubarItem>
+    )
+  }
+
+  // error
+  return (
+    <MenubarItem disabled className="opacity-70 cursor-default text-xs text-red-500">
+      Update check failed
+    </MenubarItem>
   )
 }

--- a/src/renderer/src/hooks/useAppUpdate.ts
+++ b/src/renderer/src/hooks/useAppUpdate.ts
@@ -1,0 +1,52 @@
+/**
+ * Subscribes to the main process's autoUpdater state and exposes it to the
+ * renderer along with an `installNow` action.
+ *
+ * The state machine lives in main (`src/main/index.ts` + `src/shared/types/
+ * updates.ts`); this hook is just a thin React wrapper.
+ *
+ * In dev or browser-fallback (no `window.api.updates`), state stays `idle`
+ * and `installNow` is a no-op so callers don't need to guard.
+ */
+import { useEffect, useState, useCallback } from 'react'
+import { IDLE_STATE, type UpdateState } from '../../../shared/types/updates'
+
+export interface UseAppUpdate {
+  state: UpdateState
+  installNow: () => void
+}
+
+export function useAppUpdate(): UseAppUpdate {
+  const [state, setState] = useState<UpdateState>(IDLE_STATE)
+
+  useEffect(() => {
+    const updates = window.api?.updates
+    if (!updates) return
+
+    let cancelled = false
+    updates.getState().then(
+      (s) => {
+        if (!cancelled) setState(s)
+      },
+      (err) => {
+        // Initial sync failed (e.g. main not ready, IPC channel missing) —
+        // stay on IDLE_STATE; subsequent broadcasts will still arrive.
+        console.warn('[useAppUpdate] getState failed:', err)
+      }
+    )
+
+    const off = updates.onStateChange(setState)
+    return () => {
+      cancelled = true
+      off()
+    }
+  }, [])
+
+  const installNow = useCallback(() => {
+    window.api?.updates?.installNow()?.catch((err) => {
+      console.warn('[useAppUpdate] installNow failed:', err)
+    })
+  }, [])
+
+  return { state, installNow }
+}

--- a/src/shared/types/updates.ts
+++ b/src/shared/types/updates.ts
@@ -1,0 +1,32 @@
+/**
+ * Cross-process state machine for electron-updater. The main process emits
+ * `updates:state` over IPC on every autoUpdater event; the renderer subscribes
+ * via `window.api.updates.onStateChange` and renders the badge + status line.
+ *
+ * Transitions (driven by autoUpdater events):
+ *   idle            (initial)
+ *   → checking-for-update          → checking
+ *   → update-not-available         → idle
+ *   → update-available             → downloading { progress: 0 }
+ *   → download-progress (repeated) → downloading { progress: % }
+ *   → update-downloaded            → downloaded
+ *   → error (anywhere)             → error
+ */
+export type UpdateState =
+  | { kind: 'idle' }
+  | { kind: 'checking' }
+  | { kind: 'downloading'; version: string; progress: number }
+  | { kind: 'downloaded'; version: string }
+  | { kind: 'error'; message: string }
+
+export const IDLE_STATE: UpdateState = { kind: 'idle' }
+
+/** IPC channels — kept in one place so main + preload + renderer can't drift. */
+export const UPDATE_CHANNELS = {
+  /** Main → Renderer broadcast: new UpdateState. */
+  state: 'updates:state',
+  /** Renderer → Main: read current state on mount (renderer may have started late). */
+  getState: 'updates:get-state',
+  /** Renderer → Main: quit and install the downloaded update. */
+  installNow: 'updates:install-now'
+} as const


### PR DESCRIPTION
Adds a small status badge to the Help menu trigger and a contextual line under the existing version row, so users can see whether an update is downloading, ready, or errored — instead of having to grep the log file.

## What you'll see

- **Idle** — no badge, no extra text. Help menu unchanged.
- **Downloading** — small **blue dot** on Help trigger. Menu shows: `Downloading v1.8.1… 42%`
- **Downloaded** — small **green dot** on Help trigger. Menu shows clickable: `v1.8.1 ready — Restart to apply`. Selecting it calls `autoUpdater.quitAndInstall(false, true)`.
- **Error** — small **red dot**. Menu shows: `Update check failed`.

## Architecture

| Layer | What it does |
|---|---|
| `src/shared/types/updates.ts` (new) | `UpdateState` discriminated union + IPC channel names — single source of truth across all three processes. |
| `src/main/index.ts` | Maintains state, broadcasts on each `autoUpdater` event. Exposes `updates:get-state` and `updates:install-now`. |
| `src/preload/index.ts` | Bridges `getState`, `onStateChange`, `installNow` onto `window.api.updates`. |
| `src/renderer/src/hooks/useAppUpdate.ts` (new) | Thin React wrapper: reads + subscribes. Dev/browser-fallback degrades to permanent idle. |
| `src/renderer/src/components/Navbar.tsx` | Renders the badge + menu item. |

Dev mode keeps the existing `!is.dev` gate, so dev builds always show idle.

## Test plan

- [ ] Once shipped, install on top of any prior signed build → confirm idle is invisible (no regression)
- [ ] Hold a release → confirm blue-dot + downloading text appear during download, green-dot when ready
- [ ] Click "ready — Restart to apply" → app quits and relaunches at new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)