### PR TITLE
feat(ui): per-shape pocket depth control + numeric-input cleanup

### DIFF
--- a/src/renderer/src/components/DrawingToolLayer.tsx
+++ b/src/renderer/src/components/DrawingToolLayer.tsx
@@ -8,12 +8,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppMode } from '@/hooks/useAppMode'
-import { useProject } from '@/hooks/useProject'
 import { useLayoutEngineContext, useEngineState } from '@/layout-engine'
 import type { LayoutEngine } from '@/layout-engine'
 import type { LayoutShape, BinMetadata, LayoutGroup } from '@/layout-engine/types'
 import { findBestBinForShape, type ShapeAABB } from '@/layout-engine/containment'
-import { computeDefaultPocketDepth } from '../../../shared/types/project'
 
 // ─── Coordinate conversion ──────────────────────────────────────────────────
 
@@ -114,13 +112,15 @@ function findBinForDrawnShape(
 }
 
 function pocketMetadata(
-  bin: (LayoutGroup & { metadata: BinMetadata }) | null,
-  unitHeight: number
+  bin: (LayoutGroup & { metadata: BinMetadata }) | null
 ): Record<string, unknown> | undefined {
   if (!bin) return undefined
+  // Newly drawn shapes start in "auto" mode (depth === undefined). The bake
+  // loop falls back to computeDefaultPocketDepth via `?? computeDefault…`,
+  // so the produced geometry is identical, but the sidebar can distinguish
+  // a true user override from the historical default.
   return {
     pocket: {
-      depth: computeDefaultPocketDepth(bin.metadata.heightUnits, unitHeight),
       clearance: 0.25
     }
   }
@@ -148,7 +148,6 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
   const { activeTool, setActiveTool } = useAppMode()
   const { engine } = useLayoutEngineContext()
   const { viewport } = useEngineState()
-  const unitHeight = useProject((s) => s.project?.gridfinity.unitHeight ?? 7)
 
   // Reset polygon state when switching away from polygon tool.
 
@@ -231,7 +230,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
         points: relativePoints,
         ...baseShapeProps(),
         groupId: null,
-        metadata: { ...pocketMetadata(bin, unitHeight), name }
+        metadata: { ...pocketMetadata(bin), name }
       })
       if (bin) engine.addToGroup(id, bin.id)
       engine.select([id])
@@ -243,7 +242,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
         finishingRef.current = false
       })
     },
-    [engine, setActiveTool, unitHeight]
+    [engine, setActiveTool]
   )
 
   // ─── Escape / Enter for polygon ──────────────────────────────────────────
@@ -434,7 +433,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             height: h,
             ...baseShapeProps(),
             groupId: null,
-            metadata: { ...pocketMetadata(bin, unitHeight), name }
+            metadata: { ...pocketMetadata(bin), name }
           })
           if (bin) engine.addToGroup(id, bin.id)
           engine.select([id])
@@ -462,7 +461,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             radiusY: radius,
             ...baseShapeProps(),
             groupId: null,
-            metadata: { ...pocketMetadata(bin, unitHeight), name }
+            metadata: { ...pocketMetadata(bin), name }
           })
           if (bin) engine.addToGroup(id, bin.id)
           engine.select([id])
@@ -472,7 +471,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
 
       dragStartRef.current = null
     },
-    [engine, activeTool, setActiveTool, unitHeight]
+    [engine, activeTool, setActiveTool]
   )
 
   // ─── Render ────────────────────────────────────────────────────────────────

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -11,8 +11,12 @@ import {
   useEngineState,
   isBinGroup
 } from '@/layout-engine'
-import type { BinMetadata, LayoutGroup } from '@/layout-engine'
+import type { BinMetadata, LayoutGroup, LayoutShape, LayoutEngine } from '@/layout-engine'
 import { buildSTLArrayBuffer, build3MFArrayBuffer, placementsFromGroups } from '@/lib/export-baked'
+import { computeDefaultPocketDepth, DEFAULT_GRIDFINITY_CONFIG } from '../../../shared/types/project'
+
+/** Depth threshold (mm) below the bin's max safe depth at which we warn. */
+const DEPTH_WARN_MARGIN = 2
 
 export default function Sidebar(): React.JSX.Element {
   const { mode } = useAppMode()
@@ -267,6 +271,7 @@ function LayoutSidebar(): React.JSX.Element {
               precision={1}
               onChange={(v) => engine?.updateShape(selectedShape.id, { y: v })}
             />
+            {engine && <ShapeDepthField shape={selectedShape} engine={engine} />}
           </div>
         </SidebarSection>
       )}
@@ -440,6 +445,86 @@ function SidebarSection({
         {title}
       </p>
       {children}
+    </div>
+  )
+}
+
+// ─── Shape depth field ──────────────────────────────────────
+
+/**
+ * Per-shape pocket depth control. Auto-toggle defaults to the bin's
+ * computed default (interior cavity height); switching off lets the user
+ * override with a specific value, capped at the safe maximum and warning
+ * when within DEPTH_WARN_MARGIN of that maximum.
+ *
+ * Hidden when the shape isn't grouped to a bin — depth has no meaning for
+ * top-level shapes that don't get baked.
+ */
+function ShapeDepthField({
+  shape,
+  engine
+}: {
+  shape: LayoutShape
+  engine: LayoutEngine
+}): React.JSX.Element | null {
+  const project = useProject((s) => s.project)
+  const config = project?.gridfinity ?? DEFAULT_GRIDFINITY_CONFIG
+
+  if (!shape.groupId) return null
+  const bin = engine.getGroup(shape.groupId)
+  if (!bin || !isBinGroup(bin)) return null
+
+  const maxSafe = computeDefaultPocketDepth(bin.metadata.heightUnits, config.unitHeight)
+  const meta = (shape.metadata ?? {}) as Record<string, unknown>
+  const pocket = (meta.pocket as { depth?: number | null; clearance?: number } | undefined) ?? {}
+  const isAuto = pocket.depth === undefined || pocket.depth === null
+  const effectiveDepth = isAuto ? maxSafe : pocket.depth!
+  const nearMax = !isAuto && effectiveDepth >= maxSafe - DEPTH_WARN_MARGIN
+
+  const writeDepth = (next: number | null): void => {
+    const nextMeta = {
+      ...meta,
+      pocket: {
+        clearance: pocket.clearance ?? 0.25,
+        ...(next === null ? {} : { depth: next })
+      }
+    }
+    engine.updateShape(shape.id, { metadata: nextMeta })
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="text-zinc-500">Depth</span>
+        <label className="flex items-center gap-1 text-zinc-500 cursor-pointer">
+          <span>Auto</span>
+          <Switch
+            checked={isAuto}
+            onCheckedChange={(checked) => writeDepth(checked ? null : maxSafe)}
+          />
+        </label>
+      </div>
+      {!isAuto && (
+        <NumericInput
+          label="mm"
+          value={effectiveDepth}
+          step={0.5}
+          fineStep={0.1}
+          precision={1}
+          min={0.1}
+          max={maxSafe}
+          onChange={(v) => writeDepth(v)}
+        />
+      )}
+      {nearMax && (
+        <div className="flex items-start gap-1 text-amber-600 dark:text-amber-400 text-[10px] leading-tight">
+          <span aria-hidden="true">⚠</span>
+          <span>
+            Within {DEPTH_WARN_MARGIN}mm of bin floor ({maxSafe.toFixed(1)}mm max). Print may be
+            fragile.
+          </span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/ui/numeric-input.tsx
+++ b/src/renderer/src/components/ui/numeric-input.tsx
@@ -178,24 +178,6 @@ export function NumericInput({
     [editing, editText, step, fineStep, coarseStep, precision, apply, commitEdit]
   )
 
-  // ── Steppers ─────────────────────────────────────────────────
-
-  const increment = useCallback(
-    (e: React.MouseEvent) => {
-      const s = getStep(e, step, fineStep, coarseStep)
-      apply(value + s)
-    },
-    [step, fineStep, coarseStep, value, apply]
-  )
-
-  const decrement = useCallback(
-    (e: React.MouseEvent) => {
-      const s = getStep(e, step, fineStep, coarseStep)
-      apply(value - s)
-    },
-    [step, fineStep, coarseStep, value, apply]
-  )
-
   const displayValue = displayUnit ? formatDimension(value, displayUnit) : value.toFixed(precision)
 
   return (
@@ -212,14 +194,16 @@ export function NumericInput({
         </span>
       )}
 
-      {/* Value area */}
+      {/* Value area — drag the label to scrub, scroll the input to step,
+          click to edit, arrow keys + Shift/Cmd for fine/coarse step. No
+          discrete spinner buttons by design. */}
       <div className="relative flex items-center">
         {editing ? (
           <input
             ref={inputRef}
             type="text"
             inputMode="decimal"
-            className="w-16 bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200 font-mono text-xs text-right rounded px-1 py-0.5 outline-none ring-1 ring-blue-500"
+            className="w-20 bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200 font-mono text-xs text-right rounded px-1.5 py-0.5 outline-none ring-1 ring-blue-500"
             value={editText}
             onChange={(e) => setEditText(e.target.value)}
             onBlur={commitEdit}
@@ -228,40 +212,12 @@ export function NumericInput({
         ) : (
           <button
             type="button"
-            className="w-16 bg-zinc-200/60 text-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-300 font-mono text-xs text-right rounded px-1 py-0.5 hover:bg-zinc-300/60 dark:hover:bg-zinc-700/60 transition cursor-text"
+            className="w-20 bg-zinc-200/60 text-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-300 font-mono text-xs text-right rounded px-1.5 py-0.5 hover:bg-zinc-300/60 dark:hover:bg-zinc-700/60 transition cursor-text"
             onClick={startEditing}
           >
             {displayValue}
             {suffix && <span className="text-zinc-500 ml-0.5">{suffix}</span>}
           </button>
-        )}
-
-        {/* Stepper arrows */}
-        {!editing && (
-          <div className="flex flex-col ml-0.5">
-            <button
-              type="button"
-              className="text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300 leading-none px-0.5"
-              onClick={increment}
-              tabIndex={-1}
-              aria-label="Increment"
-            >
-              <svg width="8" height="5" viewBox="0 0 8 5" fill="currentColor">
-                <path d="M4 0L8 5H0z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className="text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300 leading-none px-0.5"
-              onClick={decrement}
-              tabIndex={-1}
-              aria-label="Decrement"
-            >
-              <svg width="8" height="5" viewBox="0 0 8 5" fill="currentColor">
-                <path d="M4 5L0 0h8z" />
-              </svg>
-            </button>
-          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
First of four planned UX changes around per-shape depth (#39 of the local task list).

## What's new

### Depth field in Shape Properties
- Visible only for shapes inside a bin (top-level shapes don't get baked, so depth is meaningless).
- **Auto** toggle (default ON) — uses the bin's computed default (full interior cavity).
- Off → numeric input in mm, capped at the bin's max safe depth.
- When the entered value is within **2mm** of that max, an inline **amber warning** appears: *"Within 2mm of bin floor (X.Xmm max). Print may be fragile."*

Storage: writes to `shape.metadata.pocket.depth` (already a thing — `useBinBaker` reads it). Auto = `null` so the bake loop falls back to `computeDefaultPocketDepth`.

### NumericInput visual cleanup
The cramped up/down stepper arrows (8×5px stacked SVGs) were causing visual noise. Dropped entirely. The input still supports:
- Drag-to-scrub on the label (cursor turns to ew-resize)
- Mouse wheel to step
- Click to edit + arrow keys (Shift = fine, Cmd/Ctrl = coarse)

Slight width bump (`w-16` → `w-20`) for breathing room.

## Up next (separate PRs)
- Fill-opacity scales with depth on canvas
- Conditional depth badge for overridden shapes
- No-delay hover tooltip with shape info

## Verified locally
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test` — 319/319 still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)