### PR TITLE
feat(ui): no-delay hover tooltip on canvas shapes

### DIFF
--- a/src/renderer/src/components/DrawingToolLayer.tsx
+++ b/src/renderer/src/components/DrawingToolLayer.tsx
@@ -8,12 +8,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppMode } from '@/hooks/useAppMode'
-import { useProject } from '@/hooks/useProject'
 import { useLayoutEngineContext, useEngineState } from '@/layout-engine'
 import type { LayoutEngine } from '@/layout-engine'
 import type { LayoutShape, BinMetadata, LayoutGroup } from '@/layout-engine/types'
 import { findBestBinForShape, type ShapeAABB } from '@/layout-engine/containment'
-import { computeDefaultPocketDepth } from '../../../shared/types/project'
 
 // ─── Coordinate conversion ──────────────────────────────────────────────────
 
@@ -114,13 +112,15 @@ function findBinForDrawnShape(
 }
 
 function pocketMetadata(
-  bin: (LayoutGroup & { metadata: BinMetadata }) | null,
-  unitHeight: number
+  bin: (LayoutGroup & { metadata: BinMetadata }) | null
 ): Record<string, unknown> | undefined {
   if (!bin) return undefined
+  // Newly drawn shapes start in "auto" mode (depth === undefined). The bake
+  // loop falls back to computeDefaultPocketDepth via `?? computeDefault…`,
+  // so the produced geometry is identical, but the sidebar can distinguish
+  // a true user override from the historical default.
   return {
     pocket: {
-      depth: computeDefaultPocketDepth(bin.metadata.heightUnits, unitHeight),
       clearance: 0.25
     }
   }
@@ -148,7 +148,6 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
   const { activeTool, setActiveTool } = useAppMode()
   const { engine } = useLayoutEngineContext()
   const { viewport } = useEngineState()
-  const unitHeight = useProject((s) => s.project?.gridfinity.unitHeight ?? 7)
 
   // Reset polygon state when switching away from polygon tool.
 
@@ -231,7 +230,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
         points: relativePoints,
         ...baseShapeProps(),
         groupId: null,
-        metadata: { ...pocketMetadata(bin, unitHeight), name }
+        metadata: { ...pocketMetadata(bin), name }
       })
       if (bin) engine.addToGroup(id, bin.id)
       engine.select([id])
@@ -243,7 +242,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
         finishingRef.current = false
       })
     },
-    [engine, setActiveTool, unitHeight]
+    [engine, setActiveTool]
   )
 
   // ─── Escape / Enter for polygon ──────────────────────────────────────────
@@ -434,7 +433,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             height: h,
             ...baseShapeProps(),
             groupId: null,
-            metadata: { ...pocketMetadata(bin, unitHeight), name }
+            metadata: { ...pocketMetadata(bin), name }
           })
           if (bin) engine.addToGroup(id, bin.id)
           engine.select([id])
@@ -462,7 +461,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
             radiusY: radius,
             ...baseShapeProps(),
             groupId: null,
-            metadata: { ...pocketMetadata(bin, unitHeight), name }
+            metadata: { ...pocketMetadata(bin), name }
           })
           if (bin) engine.addToGroup(id, bin.id)
           engine.select([id])
@@ -472,7 +471,7 @@ export default function DrawingToolLayer(): React.JSX.Element | null {
 
       dragStartRef.current = null
     },
-    [engine, activeTool, setActiveTool, unitHeight]
+    [engine, activeTool, setActiveTool]
   )
 
   // ─── Render ────────────────────────────────────────────────────────────────

--- a/src/renderer/src/components/ShapeTooltip.tsx
+++ b/src/renderer/src/components/ShapeTooltip.tsx
@@ -1,0 +1,102 @@
+/**
+ * Hover tooltip for canvas shapes. Mousemove on the canvas container →
+ * engine hit-test → floating tooltip with shape name + depth, no hover delay.
+ *
+ * Skips when a drawing tool is active or when the engine reports an
+ * in-progress interaction (drag/resize) — the user is busy and a tooltip
+ * would be noise.
+ */
+import { useEffect, useState } from 'react'
+import { useLayoutEngineContext, useEngineState, isBinGroup } from '@/layout-engine'
+import { useAppMode } from '@/hooks/useAppMode'
+import { useProject } from '@/hooks/useProject'
+import { computeDefaultPocketDepth, DEFAULT_GRIDFINITY_CONFIG } from '../../../shared/types/project'
+
+interface HoverState {
+  shapeId: string
+  clientX: number
+  clientY: number
+}
+
+export default function ShapeTooltip(): React.JSX.Element | null {
+  const { engine, containerRef } = useLayoutEngineContext()
+  const { tick } = useEngineState()
+  const { activeTool } = useAppMode()
+  const unitHeight = useProject(
+    (s) => s.project?.gridfinity.unitHeight ?? DEFAULT_GRIDFINITY_CONFIG.unitHeight
+  )
+  const [hover, setHover] = useState<HoverState | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || !engine) return
+    // Don't attach listeners while a drawing tool is active — the user is
+    // busy and the drawing overlay also captures pointer events. Stale
+    // hover state is OK; the render guard below skips drawing the tooltip.
+    if (activeTool && activeTool !== 'select') return
+
+    const onMove = (e: PointerEvent): void => {
+      if (engine.isInteracting()) {
+        setHover(null)
+        return
+      }
+      const rect = container.getBoundingClientRect()
+      const vp = engine.getViewport()
+      const worldX = (e.clientX - rect.left + vp.panX) / vp.zoom
+      const worldY = (e.clientY - rect.top + vp.panY) / vp.zoom
+      const hit = engine.objectAt(worldX, worldY)
+      if (hit?.type === 'shape') {
+        setHover({ shapeId: hit.id, clientX: e.clientX, clientY: e.clientY })
+      } else {
+        setHover(null)
+      }
+    }
+    const onLeave = (): void => setHover(null)
+
+    container.addEventListener('pointermove', onMove)
+    container.addEventListener('pointerleave', onLeave)
+    return () => {
+      container.removeEventListener('pointermove', onMove)
+      container.removeEventListener('pointerleave', onLeave)
+    }
+  }, [engine, containerRef, activeTool])
+
+  if (!hover || !engine) return null
+  if (activeTool && activeTool !== 'select') return null
+  // Re-read on every tick so depth/name edits surface even if the mouse
+  // hasn't moved since the last engine mutation.
+  void tick
+  const shape = engine.getShape(hover.shapeId)
+  if (!shape) return null
+
+  const name = (shape.metadata?.name as string | undefined) ?? shape.type
+  const meta = shape.metadata as { pocket?: { depth?: number | null } } | undefined
+  const depthVal = meta?.pocket?.depth
+
+  let depthLabel = '—'
+  if (shape.groupId) {
+    const bin = engine.getGroup(shape.groupId)
+    if (bin && isBinGroup(bin)) {
+      if (depthVal === null || depthVal === undefined) {
+        const auto = computeDefaultPocketDepth(bin.metadata.heightUnits, unitHeight)
+        depthLabel = `Auto (${auto}mm)`
+      } else {
+        depthLabel = `${depthVal}mm`
+      }
+    }
+  }
+
+  return (
+    <div
+      role="tooltip"
+      style={{
+        left: hover.clientX + 12,
+        top: hover.clientY + 12
+      }}
+      className="fixed z-50 pointer-events-none rounded-md bg-zinc-900/95 px-2 py-1 text-xs text-zinc-100 shadow-lg ring-1 ring-zinc-700 backdrop-blur-sm"
+    >
+      <div className="font-medium">{name}</div>
+      <div className="text-zinc-400">Depth: {depthLabel}</div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -11,8 +11,12 @@ import {
   useEngineState,
   isBinGroup
 } from '@/layout-engine'
-import type { BinMetadata, LayoutGroup } from '@/layout-engine'
+import type { BinMetadata, LayoutGroup, LayoutShape, LayoutEngine } from '@/layout-engine'
 import { buildSTLArrayBuffer, build3MFArrayBuffer, placementsFromGroups } from '@/lib/export-baked'
+import { computeDefaultPocketDepth, DEFAULT_GRIDFINITY_CONFIG } from '../../../shared/types/project'
+
+/** Depth threshold (mm) below the bin's max safe depth at which we warn. */
+const DEPTH_WARN_MARGIN = 2
 
 export default function Sidebar(): React.JSX.Element {
   const { mode } = useAppMode()
@@ -267,6 +271,7 @@ function LayoutSidebar(): React.JSX.Element {
               precision={1}
               onChange={(v) => engine?.updateShape(selectedShape.id, { y: v })}
             />
+            {engine && <ShapeDepthField shape={selectedShape} engine={engine} />}
           </div>
         </SidebarSection>
       )}
@@ -440,6 +445,86 @@ function SidebarSection({
         {title}
       </p>
       {children}
+    </div>
+  )
+}
+
+// ─── Shape depth field ──────────────────────────────────────
+
+/**
+ * Per-shape pocket depth control. Auto-toggle defaults to the bin's
+ * computed default (interior cavity height); switching off lets the user
+ * override with a specific value, capped at the safe maximum and warning
+ * when within DEPTH_WARN_MARGIN of that maximum.
+ *
+ * Hidden when the shape isn't grouped to a bin — depth has no meaning for
+ * top-level shapes that don't get baked.
+ */
+function ShapeDepthField({
+  shape,
+  engine
+}: {
+  shape: LayoutShape
+  engine: LayoutEngine
+}): React.JSX.Element | null {
+  const project = useProject((s) => s.project)
+  const config = project?.gridfinity ?? DEFAULT_GRIDFINITY_CONFIG
+
+  if (!shape.groupId) return null
+  const bin = engine.getGroup(shape.groupId)
+  if (!bin || !isBinGroup(bin)) return null
+
+  const maxSafe = computeDefaultPocketDepth(bin.metadata.heightUnits, config.unitHeight)
+  const meta = (shape.metadata ?? {}) as Record<string, unknown>
+  const pocket = (meta.pocket as { depth?: number | null; clearance?: number } | undefined) ?? {}
+  const isAuto = pocket.depth === undefined || pocket.depth === null
+  const effectiveDepth = isAuto ? maxSafe : pocket.depth!
+  const nearMax = !isAuto && effectiveDepth >= maxSafe - DEPTH_WARN_MARGIN
+
+  const writeDepth = (next: number | null): void => {
+    const nextMeta = {
+      ...meta,
+      pocket: {
+        clearance: pocket.clearance ?? 0.25,
+        ...(next === null ? {} : { depth: next })
+      }
+    }
+    engine.updateShape(shape.id, { metadata: nextMeta })
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="text-zinc-500">Depth</span>
+        <label className="flex items-center gap-1 text-zinc-500 cursor-pointer">
+          <span>Auto</span>
+          <Switch
+            checked={isAuto}
+            onCheckedChange={(checked) => writeDepth(checked ? null : maxSafe)}
+          />
+        </label>
+      </div>
+      {!isAuto && (
+        <NumericInput
+          label="mm"
+          value={effectiveDepth}
+          step={0.5}
+          fineStep={0.1}
+          precision={1}
+          min={0.1}
+          max={maxSafe}
+          onChange={(v) => writeDepth(v)}
+        />
+      )}
+      {nearMax && (
+        <div className="flex items-start gap-1 text-amber-600 dark:text-amber-400 text-[10px] leading-tight">
+          <span aria-hidden="true">⚠</span>
+          <span>
+            Within {DEPTH_WARN_MARGIN}mm of bin floor ({maxSafe.toFixed(1)}mm max). Print may be
+            fragile.
+          </span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/Viewport.tsx
+++ b/src/renderer/src/components/Viewport.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/layout-engine'
 import type { UndoRedoDebugState } from '@/layout-engine/useEngineUndoRedo'
 import DrawingToolLayer from './DrawingToolLayer'
+import ShapeTooltip from './ShapeTooltip'
 import HintCard from './HintCard'
 
 const MOD_KEY = navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'
@@ -153,6 +154,7 @@ export default function Viewport(): React.JSX.Element {
         <LayoutEngineCanvas />
         {mode === 'layout' && <LayoutViewport />}
         {mode === 'layout' && <DrawingToolLayer />}
+        {mode === 'layout' && <ShapeTooltip />}
       </div>
       <div className={mode === 'review' ? 'h-full' : 'hidden'}>
         <ReviewCanvas bakeResults={bakeResults} baseUnit={baseUnit} />

--- a/src/renderer/src/components/ui/numeric-input.tsx
+++ b/src/renderer/src/components/ui/numeric-input.tsx
@@ -178,24 +178,6 @@ export function NumericInput({
     [editing, editText, step, fineStep, coarseStep, precision, apply, commitEdit]
   )
 
-  // ── Steppers ─────────────────────────────────────────────────
-
-  const increment = useCallback(
-    (e: React.MouseEvent) => {
-      const s = getStep(e, step, fineStep, coarseStep)
-      apply(value + s)
-    },
-    [step, fineStep, coarseStep, value, apply]
-  )
-
-  const decrement = useCallback(
-    (e: React.MouseEvent) => {
-      const s = getStep(e, step, fineStep, coarseStep)
-      apply(value - s)
-    },
-    [step, fineStep, coarseStep, value, apply]
-  )
-
   const displayValue = displayUnit ? formatDimension(value, displayUnit) : value.toFixed(precision)
 
   return (
@@ -212,14 +194,16 @@ export function NumericInput({
         </span>
       )}
 
-      {/* Value area */}
+      {/* Value area — drag the label to scrub, scroll the input to step,
+          click to edit, arrow keys + Shift/Cmd for fine/coarse step. No
+          discrete spinner buttons by design. */}
       <div className="relative flex items-center">
         {editing ? (
           <input
             ref={inputRef}
             type="text"
             inputMode="decimal"
-            className="w-16 bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200 font-mono text-xs text-right rounded px-1 py-0.5 outline-none ring-1 ring-blue-500"
+            className="w-20 bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200 font-mono text-xs text-right rounded px-1.5 py-0.5 outline-none ring-1 ring-blue-500"
             value={editText}
             onChange={(e) => setEditText(e.target.value)}
             onBlur={commitEdit}
@@ -228,40 +212,12 @@ export function NumericInput({
         ) : (
           <button
             type="button"
-            className="w-16 bg-zinc-200/60 text-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-300 font-mono text-xs text-right rounded px-1 py-0.5 hover:bg-zinc-300/60 dark:hover:bg-zinc-700/60 transition cursor-text"
+            className="w-20 bg-zinc-200/60 text-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-300 font-mono text-xs text-right rounded px-1.5 py-0.5 hover:bg-zinc-300/60 dark:hover:bg-zinc-700/60 transition cursor-text"
             onClick={startEditing}
           >
             {displayValue}
             {suffix && <span className="text-zinc-500 ml-0.5">{suffix}</span>}
           </button>
-        )}
-
-        {/* Stepper arrows */}
-        {!editing && (
-          <div className="flex flex-col ml-0.5">
-            <button
-              type="button"
-              className="text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300 leading-none px-0.5"
-              onClick={increment}
-              tabIndex={-1}
-              aria-label="Increment"
-            >
-              <svg width="8" height="5" viewBox="0 0 8 5" fill="currentColor">
-                <path d="M4 0L8 5H0z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className="text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300 leading-none px-0.5"
-              onClick={decrement}
-              tabIndex={-1}
-              aria-label="Decrement"
-            >
-              <svg width="8" height="5" viewBox="0 0 8 5" fill="currentColor">
-                <path d="M4 5L0 0h8z" />
-              </svg>
-            </button>
-          </div>
         )}
       </div>
     </div>

--- a/src/renderer/src/layout-engine/LayoutEngineContext.tsx
+++ b/src/renderer/src/layout-engine/LayoutEngineContext.tsx
@@ -1,11 +1,13 @@
 import { useContext, useEffect, useRef, useState, useCallback } from 'react'
 import { useTheme } from '@unstable-studios/ui'
 import { resolveColors } from '@/lib/theme-config'
+import { useProject } from '@/hooks/useProject'
 import type { EngineType } from './create-engine'
 import { createLayoutEngine } from './create-engine'
 import type { LayoutEngine } from './interface'
 import { LayoutEngineCtx } from './engine-context'
 import { GestureRecognizer } from './gesture-recognizer'
+import { DEFAULT_GRIDFINITY_CONFIG } from '../../../shared/types/project'
 // Import adapters to trigger self-registration
 import './fabric-engine'
 import './konva-engine'
@@ -33,6 +35,9 @@ export function LayoutEngineProvider({
     transient: ReturnType<LayoutEngine['getTransientState']>
   } | null>(null)
   const { resolvedTheme } = useTheme()
+  const unitHeight = useProject(
+    (s) => s.project?.gridfinity.unitHeight ?? DEFAULT_GRIDFINITY_CONFIG.unitHeight
+  )
 
   useEffect(() => {
     const container = containerRef.current
@@ -49,6 +54,9 @@ export function LayoutEngineProvider({
       gridOrigin:
         resolvedTheme === 'light' ? 'rgba(100, 100, 120, 0.4)' : 'rgba(113, 113, 122, 0.35)'
     })
+
+    // Sync unitHeight so depth-based shape opacity reflects the project config.
+    newEngine.setUnitHeight(unitHeight)
 
     // Derive sidebar inset from measured sidebar element, fallback to 0
     const sidebar = sidebarRef.current
@@ -113,6 +121,12 @@ export function LayoutEngineProvider({
         resolvedTheme === 'light' ? 'rgba(100, 100, 120, 0.4)' : 'rgba(113, 113, 122, 0.35)'
     })
   }, [resolvedTheme, engineState.engine])
+
+  // Push unitHeight changes (rare — only when the user changes Gridfinity
+  // preset/config) into the engine so depth-based opacity stays accurate.
+  useEffect(() => {
+    engineState.engine?.setUnitHeight(unitHeight)
+  }, [unitHeight, engineState.engine])
 
   const handleSetEngineType = useCallback((type: EngineType) => {
     setEngineState((prev) => {

--- a/src/renderer/src/layout-engine/fabric-engine.ts
+++ b/src/renderer/src/layout-engine/fabric-engine.ts
@@ -18,6 +18,8 @@ import { checkGroupCollision } from './collision'
 import type { HitResult } from './input-action-handler'
 import { computeEdgeAnchor } from './input-math'
 import { findContainingBinGroup } from './containment'
+import { depthToOpacity } from '../../../shared/types/project'
+import { isBinGroup } from './types'
 
 // ─── Constants ──────────────────────────────────────────────────────────────────
 
@@ -184,6 +186,8 @@ export class FabricEngine implements LayoutEngine {
     gridOrigin: DEFAULT_GRID_ORIGIN
   }
   private insets: ViewportInsets = {}
+  /** mm per height unit — used to derive depth-based shape opacity. */
+  private unitHeight = 7
   /** Currently highlighted group ID during shape drag (for drop-target feedback). */
   private highlightedGroupId: string | null = null
   /**
@@ -275,6 +279,7 @@ export class FabricEngine implements LayoutEngine {
     const obj = layoutShapeToFabric(shape)
     this.shapeMap.set(shape.id, { ...shape })
     this.fabricMap.set(shape.id, obj)
+    this.applyDepthOpacity(shape, obj)
 
     if (shape.groupId && this.rendererMap.has(shape.groupId)) {
       // shape.x/y is already group-local (snapshot semantics). attachChild
@@ -287,6 +292,26 @@ export class FabricEngine implements LayoutEngine {
 
     this.canvas?.requestRenderAll()
     this.emitter.emit('shapeCreated', { shape: { ...shape } })
+  }
+
+  /**
+   * Sets the fabric object's `opacity` based on the shape's pocket depth
+   * relative to the bin's max safe depth. Auto (depth null/undef) → 1.0.
+   * Top-level shapes (no groupId) → 1.0.
+   */
+  private applyDepthOpacity(shape: LayoutShape, obj: fabric.FabricObject): void {
+    if (!shape.groupId) {
+      obj.set('opacity', 1)
+      return
+    }
+    const group = this.groupMap.get(shape.groupId)
+    if (!group || !isBinGroup(group)) {
+      obj.set('opacity', 1)
+      return
+    }
+    const meta = shape.metadata as { pocket?: { depth?: number | null } } | undefined
+    const opacity = depthToOpacity(meta?.pocket?.depth, group.metadata.heightUnits, this.unitHeight)
+    obj.set('opacity', opacity)
   }
 
   updateShape(id: string, patch: Partial<LayoutShape>): void {
@@ -320,6 +345,10 @@ export class FabricEngine implements LayoutEngine {
 
     if (patch.lockAspectRatio !== undefined) {
       obj.set('lockUniScaling', patch.lockAspectRatio)
+    }
+
+    if (patch.metadata !== undefined) {
+      this.applyDepthOpacity(updated, obj)
     }
 
     obj.setCoords()
@@ -732,6 +761,17 @@ export class FabricEngine implements LayoutEngine {
 
   getGridConfig(): GridConfig {
     return { ...this.gridConfig }
+  }
+
+  setUnitHeight(mm: number): void {
+    if (mm === this.unitHeight) return
+    this.unitHeight = mm
+    // Refresh opacities for every grouped shape since maxDepth changed.
+    for (const [id, shape] of this.shapeMap) {
+      const obj = this.fabricMap.get(id)
+      if (obj) this.applyDepthOpacity(shape, obj)
+    }
+    this.canvas?.requestRenderAll()
   }
 
   // ─── Theme ───────────────────────────────────────────────────────────────

--- a/src/renderer/src/layout-engine/interface.ts
+++ b/src/renderer/src/layout-engine/interface.ts
@@ -79,6 +79,14 @@ export interface LayoutEngine {
   // ─── Theme ────────────────────────────────────────────────────────────────
   setThemeColors(colors: { background: string; grid: string; gridOrigin: string }): void
 
+  /**
+   * Update the project's `unitHeight` (mm per height unit). Used to derive
+   * each shape's render-time opacity from its pocket depth — see
+   * `depthToOpacity` in shared/types/project. Triggers a refresh of all
+   * grouped shapes' opacities.
+   */
+  setUnitHeight(mm: number): void
+
   // ─── Capabilities ──────────────────────────────────────────────────────────
   capabilities(): Set<string>
 

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -17,6 +17,8 @@ import { KonvaGroupRenderer } from './konva-group-renderer'
 import { checkGroupCollision } from './collision'
 import type { HitResult } from './input-action-handler'
 import { findContainingBinGroup } from './containment'
+import { isBinGroup } from './types'
+import { depthToOpacity } from '../../../shared/types/project'
 
 // ─── Constants ──────────────────────────────────────────────────────────────────
 
@@ -138,6 +140,8 @@ export class KonvaEngine implements LayoutEngine {
   private bgRect: Konva.Rect | null = null
   private gridBgRect: Konva.Rect | null = null
   private insets: ViewportInsets = {}
+  /** mm per height unit — used to derive depth-based shape opacity. */
+  private unitHeight = 7
   /** Currently highlighted group ID during shape drag (for drop-target feedback). */
   private highlightedGroupId: string | null = null
 
@@ -362,6 +366,7 @@ export class KonvaEngine implements LayoutEngine {
       this.transformer?.moveToTop()
     }
 
+    this.applyDepthOpacity(shape, node)
     this.mainLayer.batchDraw()
     this.emitter.emit('shapeCreated', { shape: { ...shape } })
   }
@@ -399,6 +404,10 @@ export class KonvaEngine implements LayoutEngine {
 
     node.setAttrs(attrs)
 
+    if (patch.metadata !== undefined) {
+      this.applyDepthOpacity(updated, node)
+    }
+
     // If lockAspectRatio changed and this node is selected, update transformer
     if (patch.lockAspectRatio !== undefined && this.transformer) {
       const selectedIds = this.getSelectedIds()
@@ -411,6 +420,26 @@ export class KonvaEngine implements LayoutEngine {
     }
 
     this.mainLayer?.batchDraw()
+  }
+
+  /**
+   * Sets the konva node's `opacity` based on the shape's pocket depth
+   * relative to the bin's max safe depth. Auto (depth null/undef) → 1.0.
+   * Top-level shapes (no groupId) → 1.0.
+   */
+  private applyDepthOpacity(shape: LayoutShape, node: Konva.Shape): void {
+    if (!shape.groupId) {
+      node.opacity(1)
+      return
+    }
+    const group = this.groupMap.get(shape.groupId)
+    if (!group || !isBinGroup(group)) {
+      node.opacity(1)
+      return
+    }
+    const meta = shape.metadata as { pocket?: { depth?: number | null } } | undefined
+    const opacity = depthToOpacity(meta?.pocket?.depth, group.metadata.heightUnits, this.unitHeight)
+    node.opacity(opacity)
   }
 
   removeShape(id: string): void {
@@ -1055,6 +1084,17 @@ export class KonvaEngine implements LayoutEngine {
 
   getGridConfig(): GridConfig {
     return { ...this.gridConfig }
+  }
+
+  setUnitHeight(mm: number): void {
+    if (mm === this.unitHeight) return
+    this.unitHeight = mm
+    // Refresh opacities for every grouped shape since maxDepth changed.
+    for (const [id, shape] of this.shapeMap) {
+      const node = this.konvaMap.get(id)
+      if (node) this.applyDepthOpacity(shape, node)
+    }
+    this.mainLayer?.batchDraw()
   }
 
   // ─── Theme ───────────────────────────────────────────────────────────────

--- a/src/shared/types/project.ts
+++ b/src/shared/types/project.ts
@@ -178,6 +178,30 @@ export function computeDefaultPocketDepth(heightUnits: number, unitHeight: numbe
   return Math.max(0.1, Math.round(depth * 10) / 10)
 }
 
+/**
+ * Map a pocket's depth (mm) to a render-time opacity in [0.5, 1.0].
+ *
+ *   depth ≈ 0    → 0.50 (very faint)
+ *   depth = max  → 1.00 (full)
+ *
+ * `null`/`undefined` (auto) returns 1.0 — the default IS the max safe depth,
+ * so visually the shape sits at the deeper end of the spectrum.
+ *
+ * Used by the layout engine's shape renderers to give an at-a-glance
+ * visual cue for relative pocket depths.
+ */
+export function depthToOpacity(
+  depth: number | null | undefined,
+  heightUnits: number,
+  unitHeight: number
+): number {
+  if (depth === null || depth === undefined) return 1
+  const max = computeDefaultPocketDepth(heightUnits, unitHeight)
+  if (max <= 0) return 1
+  const ratio = Math.max(0, Math.min(1, depth / max))
+  return 0.5 + 0.5 * ratio
+}
+
 export const DEFAULT_GRIDFINITY_CONFIG: GridfinityConfig = GRIDFINITY_PRESETS.standard
 
 export function createEmptyProject(name: string = 'Untitled Project'): ProjectData {


### PR DESCRIPTION
Stacks on #347 (which stacks on #346).

Final piece of the per-shape depth UX trio:

- #346 — Depth field in sidebar
- #347 — Canvas opacity scales with depth
- **#348 (this) — Hover tooltip with name + exact depth**

## What it does

Hovering a shape on the canvas shows a small tooltip near the cursor, no hover delay, styled to match the app theme. Content:

- Shape's `metadata.name` when set, else the shape type
- Depth: `Auto (X mm)` when null/undef (shows the computed default so users can see what auto resolves to), else `X mm`
- `—` for top-level shapes (no parent bin)

## Skipped when

- A drawing tool is active (user is busy; the drawing overlay also captures pointer events)
- `engine.isInteracting()` returns true (mid-drag/resize)
- Cursor isn't over a shape

## Implementation

Uses `engine.objectAt(worldX, worldY)` (already in the LayoutEngine interface for click-select) for hit-testing — no new engine plumbing. React component listens on the canvas container's pointermove, translates screen→world via the viewport state, renders a `position: fixed` div at `cursor + 12px`. Re-reads on engine tick so sidebar edits surface without needing a mouse move.

## Verified locally

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test` — 319/319 still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)