### PR TITLE
fix(core): evict shapes whose centroid leaves a resized bin

### DIFF
--- a/src/renderer/src/layout-engine/__tests__/layout-engine.contract.test.ts
+++ b/src/renderer/src/layout-engine/__tests__/layout-engine.contract.test.ts
@@ -345,6 +345,40 @@ describe.each(engineTypes)('LayoutEngine contract (%s)', (engineType) => {
       expect(finalRect.y).toBeCloseTo(-2, 0)
       expect(finalRect.groupId).toBe('bin')
     })
+
+    it('C29 (#297): shrinking a bin past a child evicts the child to top-level', () => {
+      // Bin spans world x ∈ [0, 200], y ∈ [0, 200]. Centroid (100, 100).
+      // Child at world (180, 100) → local (80, 0). Inside the bin's right edge.
+      const bin = makeGroup({ id: 'bin', x: 0, y: 200, width: 200, height: 200 })
+      const rect = makeRect({ id: 'r1', x: 80, y: 0, width: 20, height: 20, groupId: 'bin' })
+
+      engine.createGroup({ ...bin, childIds: ['r1'] })
+      engine.addShape(rect)
+
+      // Shrink the bin to 100×200 — child's world centroid (180, 100) is now
+      // outside the new bin's right edge (which sits at x=100).
+      engine.updateGroup('bin', { width: 100 })
+
+      // Child should have been evicted to top-level.
+      const updated = engine.getShape('r1')!
+      expect(updated.groupId).toBeNull()
+      expect(engine.getGroup('bin')!.childIds).not.toContain('r1')
+    })
+
+    it('C30 (#297): shrinking a bin still containing the child keeps it parented', () => {
+      const bin = makeGroup({ id: 'bin', x: 0, y: 200, width: 200, height: 200 })
+      // Child at world (90, 100) → local (-10, 0). Well inside the new bin too.
+      const rect = makeRect({ id: 'r1', x: -10, y: 0, width: 20, height: 20, groupId: 'bin' })
+
+      engine.createGroup({ ...bin, childIds: ['r1'] })
+      engine.addShape(rect)
+
+      engine.updateGroup('bin', { width: 120 })
+
+      const updated = engine.getShape('r1')!
+      expect(updated.groupId).toBe('bin')
+      expect(engine.getGroup('bin')!.childIds).toContain('r1')
+    })
   })
 
   // ─── C9-C11: Selection ──────────────────────────────────────────────────────

--- a/src/renderer/src/layout-engine/containment.ts
+++ b/src/renderer/src/layout-engine/containment.ts
@@ -5,7 +5,7 @@
  * world-space point using the lower-left corner coordinate convention.
  */
 
-import type { LayoutGroup, BinMetadata } from './types'
+import type { LayoutGroup, LayoutShape, BinMetadata } from './types'
 import { isBinGroup } from './types'
 
 /**
@@ -117,4 +117,34 @@ export function findBestBinForShape(
   }
 
   return bestByCentroid ?? bestByOverlap?.bin ?? null
+}
+
+/**
+ * Find children whose world centroid lies outside the bin's AABB. Used after
+ * a bin resize to evict shapes that no longer fit so they remain selectable
+ * (and don't bake pockets that extend past the bin's walls).
+ *
+ * Children store coords relative to the parent's centroid, so the world
+ * centroid is `(bin.x + bin.width/2 + shape.x, bin.y - bin.height/2 + shape.y)`.
+ *
+ * Edge inclusivity: a child centroid sitting exactly on the bin edge counts
+ * as inside (not evicted) — matches `findContainingBinGroup`'s convention.
+ */
+export function findChildrenOutsideBin(bin: LayoutGroup, children: LayoutShape[]): string[] {
+  const minX = bin.x
+  const maxX = bin.x + bin.width
+  const minY = bin.y - bin.height
+  const maxY = bin.y
+  const cxBin = bin.x + bin.width / 2
+  const cyBin = bin.y - bin.height / 2
+
+  const out: string[] = []
+  for (const child of children) {
+    const cx = cxBin + child.x
+    const cy = cyBin + child.y
+    if (cx < minX || cx > maxX || cy < minY || cy > maxY) {
+      out.push(child.id)
+    }
+  }
+  return out
 }

--- a/src/renderer/src/layout-engine/fabric-engine.ts
+++ b/src/renderer/src/layout-engine/fabric-engine.ts
@@ -17,7 +17,7 @@ import { FabricGroupRenderer } from './fabric-group-renderer'
 import { checkGroupCollision } from './collision'
 import type { HitResult } from './input-action-handler'
 import { computeEdgeAnchor } from './input-math'
-import { findContainingBinGroup } from './containment'
+import { findContainingBinGroup, findChildrenOutsideBin } from './containment'
 import { depthToOpacity } from '../../../shared/types/project'
 import { isBinGroup } from './types'
 
@@ -470,7 +470,33 @@ export class FabricEngine implements LayoutEngine {
     }
 
     renderer.update(patch, group)
+
+    if (patch.width !== undefined || patch.height !== undefined) {
+      this.evictChildrenOutsideGroup(group)
+    }
+
     this.emitter.emit('groupChanged', { groupId: id, childIds: [...group.childIds] })
+  }
+
+  /**
+   * After a group resize, detach any child shape whose world centroid lies
+   * outside the group's new AABB. Otherwise they'd remain parented but
+   * unselectable (hit-testing is gated by the parent group's AABB) and (for
+   * bins) would bake pockets that extend past the bin walls. Issue #297.
+   *
+   * Reads child coords via `getShape` (which derives them from the live
+   * fabric object) rather than `shapeMap`, since the in-place dx/dy
+   * compensation in resize paths doesn't write back to the shape map.
+   */
+  private evictChildrenOutsideGroup(group: LayoutGroup): void {
+    if (group.childIds.length === 0) return
+    const children = group.childIds
+      .map((cid) => this.getShape(cid))
+      .filter((s): s is LayoutShape => s !== undefined)
+    const toEvict = findChildrenOutsideBin(group, children)
+    for (const cid of toEvict) {
+      this.removeFromGroup(cid)
+    }
   }
 
   removeGroup(id: string): void {
@@ -1342,6 +1368,7 @@ export class FabricEngine implements LayoutEngine {
       }
 
       renderer.update({ x: finalX, y: finalY, width: newW, height: newH }, group)
+      this.evictChildrenOutsideGroup(group)
       this.preDragState.delete(groupId)
       this.lastGoodPos.delete(groupId)
       this.emitter.emit('groupResized', { id: groupId, width: newW, height: newH })

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -16,7 +16,7 @@ import { registerEngine } from './create-engine'
 import { KonvaGroupRenderer } from './konva-group-renderer'
 import { checkGroupCollision } from './collision'
 import type { HitResult } from './input-action-handler'
-import { findContainingBinGroup } from './containment'
+import { findContainingBinGroup, findChildrenOutsideBin } from './containment'
 import { isBinGroup } from './types'
 import { depthToOpacity } from '../../../shared/types/project'
 
@@ -537,6 +537,10 @@ export class KonvaEngine implements LayoutEngine {
             meta.widthUnits = Math.round(width / this.gridConfig.size)
             meta.depthUnits = Math.round(height / this.gridConfig.size)
           }
+          // Eviction-on-resize (#297) — same logic as updateGroup, also
+          // needed here because the user-handle resize path commits state
+          // directly via this callback and doesn't go through updateGroup.
+          this.evictChildrenOutsideGroup(g)
         }
         this.emitter.emit('groupResized', { id, width, height })
         this.emitter.emit('groupChanged', { groupId: id, childIds: [...(g?.childIds ?? [])] })
@@ -600,7 +604,33 @@ export class KonvaEngine implements LayoutEngine {
     }
 
     renderer.update(patch, group)
+
+    if (patch.width !== undefined || patch.height !== undefined) {
+      this.evictChildrenOutsideGroup(group)
+    }
+
     this.emitter.emit('groupChanged', { groupId: id, childIds: [...group.childIds] })
+  }
+
+  /**
+   * After a group resize, detach any child shape whose world centroid lies
+   * outside the group's new AABB. Otherwise they'd remain parented but
+   * unselectable (hit-testing is gated by the parent group's AABB) and (for
+   * bins) would bake pockets that extend past the bin walls. Issue #297.
+   *
+   * Reads child coords via `getShape` (which derives them from the live
+   * konva node) rather than `shapeMap`, since the in-place dx/dy
+   * compensation in resize paths doesn't write back to the shape map.
+   */
+  private evictChildrenOutsideGroup(group: LayoutGroup): void {
+    if (group.childIds.length === 0) return
+    const children = group.childIds
+      .map((cid) => this.getShape(cid))
+      .filter((s): s is LayoutShape => s !== undefined)
+    const toEvict = findChildrenOutsideBin(group, children)
+    for (const cid of toEvict) {
+      this.removeFromGroup(cid)
+    }
   }
 
   removeGroup(id: string): void {


### PR DESCRIPTION
Closes #297.

## Bug

When the user shrunk a bin past one of its child shapes, the shape remained parented to the bin and rendered at its original world position — outside the bin's visible footprint. Two consequences:

- Hit-testing is gated by the parent group's AABB, so the shape became **unselectable** on the part of its body extending past the bin walls.
- Pocket geometry would extend past the bin walls during bake.

## Fix

After `updateGroup` applies a width/height patch, walk the group's child shapes. For any whose **world centroid** is outside the group's **new** AABB, call `removeFromGroup` to detach to top-level. The shape stays at the same world position and becomes selectable + bake-correct again. If the user later drags it back into a bin, the existing drag-end reassignment logic re-parents it.

Engine-agnostic via a new `findChildrenOutsideBin(group, children)` helper in `containment.ts` — both Fabric and Konva adapters share the AABB math.

## Tests

Two contract tests added per engine (4 total):

- **C29**: shrinking a bin past a child evicts the child to top-level
- **C30**: shrinking a bin still containing the child keeps it parented

Full suite: 319 → 323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)