### PR TITLE
fix(core): metadata changes ride a tick + Fabric tooltip finds grouped shapes

### DIFF
--- a/src/renderer/src/layout-engine/fabric-engine.ts
+++ b/src/renderer/src/layout-engine/fabric-engine.ts
@@ -353,6 +353,21 @@ export class FabricEngine implements LayoutEngine {
 
     obj.setCoords()
     this.canvas?.requestRenderAll()
+
+    // Emit a generic update event for any patch that doesn't already have
+    // a more specific event (move/resize). React subscribers tick on this
+    // so the sidebar / tooltip pick up metadata changes (depth, name, …).
+    const isPositionOnly =
+      Object.keys(patch).length > 0 &&
+      Object.keys(patch).every((k) => k === 'x' || k === 'y' || k === 'id')
+    const isResizeOnly =
+      Object.keys(patch).length > 0 &&
+      Object.keys(patch).every(
+        (k) => k === 'width' || k === 'height' || k === 'radiusX' || k === 'radiusY' || k === 'id'
+      )
+    if (!isPositionOnly && !isResizeOnly) {
+      this.emitter.emit('shapeUpdated', { id })
+    }
   }
 
   removeShape(id: string): void {
@@ -928,17 +943,27 @@ export class FabricEngine implements LayoutEngine {
   objectAt(worldX: number, worldY: number): HitResult | null {
     if (!this.canvas) return null
     const point = new fabric.Point(worldX, worldY)
+
+    // Shapes first — they render above bins. fabricMap covers every shape
+    // regardless of whether it's a top-level canvas object or a child of a
+    // bin's fabric.Group, so this catches grouped shapes too (which the
+    // canvas-level `getObjects()` walk would miss).
+    for (const [shapeId, obj] of this.fabricMap) {
+      if (!obj.evented) continue
+      if (obj.containsPoint(point)) {
+        return { type: 'shape', id: shapeId }
+      }
+    }
+
+    // Then groups — the bin background.
     const objects = this.canvas.getObjects()
-    // Iterate in reverse for topmost-first hit order
     for (let i = objects.length - 1; i >= 0; i--) {
       const obj = objects[i]
       if (!obj.evented) continue
-      if (obj.containsPoint(point)) {
-        const rec = obj as unknown as Record<string, unknown>
-        const groupId = rec[GROUP_DATA_KEY] as string | undefined
-        if (groupId) return { type: 'group', id: groupId }
-        const shapeId = rec[SHAPE_DATA_KEY] as string | undefined
-        if (shapeId) return { type: 'shape', id: shapeId }
+      const rec = obj as unknown as Record<string, unknown>
+      const groupId = rec[GROUP_DATA_KEY] as string | undefined
+      if (groupId && obj.containsPoint(point)) {
+        return { type: 'group', id: groupId }
       }
     }
     return null

--- a/src/renderer/src/layout-engine/konva-engine.ts
+++ b/src/renderer/src/layout-engine/konva-engine.ts
@@ -420,6 +420,21 @@ export class KonvaEngine implements LayoutEngine {
     }
 
     this.mainLayer?.batchDraw()
+
+    // Emit a generic update event for any patch that doesn't already have
+    // a more specific event (move/resize). React subscribers tick on this
+    // so the sidebar / tooltip pick up metadata changes (depth, name, …).
+    const isPositionOnly =
+      Object.keys(patch).length > 0 &&
+      Object.keys(patch).every((k) => k === 'x' || k === 'y' || k === 'id')
+    const isResizeOnly =
+      Object.keys(patch).length > 0 &&
+      Object.keys(patch).every(
+        (k) => k === 'width' || k === 'height' || k === 'radiusX' || k === 'radiusY' || k === 'id'
+      )
+    if (!isPositionOnly && !isResizeOnly) {
+      this.emitter.emit('shapeUpdated', { id })
+    }
   }
 
   /**

--- a/src/renderer/src/layout-engine/types.ts
+++ b/src/renderer/src/layout-engine/types.ts
@@ -194,6 +194,12 @@ export type EngineEventMap = {
   }
   shapeCreated: { shape: LayoutShape }
   shapeDeleted: { id: string }
+  /**
+   * Emitted by `updateShape` for any patch that doesn't fall under
+   * `shapeMoved` or `shapeResized` — primarily metadata mutations
+   * (depth, name, etc.). Subscribers can re-read engine data to refresh.
+   */
+  shapeUpdated: { id: string }
   groupChanged: { groupId: string; childIds: string[] }
   groupMoved: { id: string; x: number; y: number }
   groupResized: { id: string; width: number; height: number }

--- a/src/renderer/src/layout-engine/useLayoutEngine.ts
+++ b/src/renderer/src/layout-engine/useLayoutEngine.ts
@@ -45,6 +45,7 @@ export function useEngineState(): EngineState {
         'shapeMoved',
         'shapeResized',
         'shapeCreated',
+        'shapeUpdated',
         'shapeDeleted',
         'groupChanged',
         'groupMoved',


### PR DESCRIPTION
Two unrelated bugs surfaced by trying out the depth UX in v1.10.0.

## #1 — Sidebar / opacity stale until selection change

`updateShape` only ever emitted `shapeMoved` / `shapeResized` for explicit position or dimension patches. Metadata-only patches (e.g. depth) updated `shapeMap` silently, so the React useSyncExternalStore tick never advanced and memos like the sidebar's `selectedShape` kept reading stale data. Workaround: click away and back to force re-read.

**Fix**: new generic `shapeUpdated` event in the engine event map, emitted from `updateShape` for any patch that isn't a pure move-only or resize-only change. Subscribed by `useLayoutEngine` alongside the existing mutation events.

## #2 — Hover tooltip never showed in Fabric

Fabric's `objectAt` walked `canvas.getObjects()` and called `containsPoint`, but shapes inside a bin live as children of `fabric.Group` — not direct canvas objects — so the loop missed every grouped shape. Konva's `stage.getIntersection` traverses the full scene graph, hence the tooltip worked there.

**Fix**: restructure Fabric's `objectAt` to do two passes:
1. Walk `fabricMap` (every shape, grouped or not) — shapes render above bins so they win the hit when present.
2. Walk top-level canvas objects for groups (bin backgrounds).

## Not addressed yet

The "depth deeper than the model allows causes erratic behavior + eviction" issue. The numeric input clamps via `max={maxSafe}` and `apply` calls `clamp` before `onChange`, so values can't actually exceed maxSafe by typing or wheel/scrub. I suspect #1 was masking the situation — when the sidebar showed a stale value, the user retried, and the resulting state interleavings produced the eviction. Worth retesting once these two fixes ship; if #3 still repros, I'll dig in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)